### PR TITLE
Update meta.yaml

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -7,7 +7,7 @@ source:
 
 requirements:
   build:
-    - python=3.6
+    - python
     - taxcalc
     - setuptools
     - paramtools


### PR DESCRIPTION
Setting `python=3.6` in `meta.yaml` seemed to override the conda build command:

```bash
: Package-Builder is building package for Python 3.7
CMD: conda build --python 3.7 --old-build-string --channel pslmodels --override-channels --no-anaconda-upload --output-folder pkgbld_output conda.recipe
No numpy version specified in conda_build_config.yaml.  Falling back to default numpy value of 1.11
WARNING:conda_build.metadata:No numpy version specified in conda_build_config.yaml.  Falling back to default numpy value of 1.11
INFO:conda_build.variants:Adding in variants from internal_defaults
INFO:conda_build.variants:Adding in variants from config.variant
INFO:conda_build.metadata:Attempting to finalize metadata for ccc
WARNING: symlink_conda() is deprecated.
zip_safe flag not set; analyzing archive contents...



######### Note python 36 references here #########
ccc.__pycache__.data.cpython-36: module references __file__
ccc.__pycache__.parameters.cpython-36: module references __file__
ccc.__pycache__.utils.cpython-36: module references __file__
INFO:conda_build.build:Packaging ccc
INFO:conda_build.build:Packaging ccc-1.0.0-py36_0
########################################################



Importing conda-verify failed.  Please be sure to test your packages.  conda install conda-verify to make this message go away.
WARNING:conda_build.build:Importing conda-verify failed.  Please be sure to test your packages.  conda install conda-verify to make this message go away.
INFO:conda_build.variants:Adding in variants from /var/folders/4z/n7jpw50s1rlfq9_r35rjxh1w0000gq/T/tmp2a7iv5r0/info/recipe/conda_build_config.yaml
WARNING: symlink_conda() is deprecated.
: Package-Builder is converting package for Python 3.7
pkgfile: ccc-1.0.0-py37_0.tar.bz2
CMD: conda convert -p linux-64 -o pkgbld_output pkgbld_output/osx-64/ccc-1.0.0-py37_0.tar.bz2
Traceback (most recent call last):
  File "/Users/henrydoupe/anaconda3/envs/pkgbld-dev/bin/conda-convert", line 11, in <module>
    sys.exit(main())
  File "/Users/henrydoupe/anaconda3/envs/pkgbld-dev/lib/python3.7/site-packages/conda_build/cli/main_convert.py", line 130, in main
    return execute(sys.argv[1:])
  File "/Users/henrydoupe/anaconda3/envs/pkgbld-dev/lib/python3.7/site-packages/conda_build/cli/main_convert.py", line 126, in execute
    api.convert(f, **args.__dict__)
  File "/Users/henrydoupe/anaconda3/envs/pkgbld-dev/lib/python3.7/site-packages/conda_build/api.py", line 312, in convert
    dry_run=dry_run, dependencies=dependencies)
  File "/Users/henrydoupe/anaconda3/envs/pkgbld-dev/lib/python3.7/site-packages/conda_build/convert.py", line 758, in conda_convert
    if len(retrieve_c_extensions(file_path)) > 0 and not force:
  File "/Users/henrydoupe/anaconda3/envs/pkgbld-dev/lib/python3.7/site-packages/conda_build/convert.py", line 41, in retrieve_c_extensions
    with tarfile.open(file_path) as tar:
  File "/Users/henrydoupe/anaconda3/envs/pkgbld-dev/lib/python3.7/tarfile.py", line 1573, in open
    return func(name, "r", fileobj, **kwargs)
  File "/Users/henrydoupe/anaconda3/envs/pkgbld-dev/lib/python3.7/tarfile.py", line 1638, in gzopen
    fileobj = gzip.GzipFile(name, mode + "b", compresslevel, fileobj)
  File "/Users/henrydoupe/anaconda3/envs/pkgbld-dev/lib/python3.7/gzip.py", line 163, in __init__
    fileobj = self.myfileobj = builtins.open(filename, mode or 'rb')
FileNotFoundError: [Errno 2] No such file or directory: '/Users/henrydoupe/temporary_pkgbld_working_dir/Cost-of-Capital-Calculator/pkgbld_output/osx-64/ccc-1.0.0-py37_0.tar.bz2'
Traceback (most recent call last):
  File "/Users/henrydoupe/Documents/Package-Builder/pkgbld/utils.py", line 20, in os_call
    subprocess.run(cmd, shell=True, check=True, stdout=subprocess.PIPE)
  File "/Users/henrydoupe/anaconda3/envs/pkgbld-dev/lib/python3.7/subprocess.py", line 487, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command 'conda convert -p linux-64 -o pkgbld_output pkgbld_output/osx-64/ccc-1.0.0-py37_0.tar.bz2' returned non-zero exit status 1.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/henrydoupe/anaconda3/envs/pkgbld-dev/bin/pbrelease", line 11, in <module>
    load_entry_point('pkgbld', 'console_scripts', 'pbrelease')()
  File "/Users/henrydoupe/Documents/Package-Builder/pkgbld/cli.py", line 103, in main
    local=args.local, dryrun=args.dryrun)
  File "/Users/henrydoupe/Documents/Package-Builder/pkgbld/release.py", line 210, in release
    u.os_call(cmd)
  File "/Users/henrydoupe/Documents/Package-Builder/pkgbld/utils.py", line 25, in os_call
    raise OSError(msg.format(err.returncode, cmd, err.output))
OSError: non-zero return code 1 generated by command:
conda convert -p linux-64 -o pkgbld_output pkgbld_output/osx-64/ccc-1.0.0-py37_0.tar.bz2
>output: b''
```