### PR TITLE
Add .coveragerc file so tests are not included in code line count

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit =
+    ccc/tests/*

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 MANIFEST
 ccc.egg-info
 .coverage
-.coveragerc
 htmlcov/*
 *.aux
 *.bbl


### PR DESCRIPTION
Correct mistake in PR #263 that causes the project code-line count to include not only the lines of code in the `ccc` directory (which is correct), but also the lines of code in the `ccc/tests` directory (which is incorrect).
A coverage statistic is supposed to say what fraction of the project's code (in `ccc`) is tested by the pytest suite in `ccc/tests`.  My mistake in PR #263 was to forget to do `git add .coveragerc` before the last commit.  This pull request fixes that mistake.

Note that the GitHub coverage test "failed" because this change (correctly) lowers the coverage rate by a couple percent.  Here is what the incorrect coverage report looked like for PR #266.

<img width="1156" alt="Screen Shot 2019-06-07 at 2 19 27 PM" src="https://user-images.githubusercontent.com/12170745/59222194-ec75a900-8b96-11e9-990b-51e6ff291282.png">

Now after the changes in this PR, the project code-line count is only 1070 because the lines of code in `ccc/tests` have been (correctly) excluded from the project total.