### PR TITLE
Activate PEP8 testing for each GitHub check-in

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,7 @@ install:
 
 # command to run tests
 script:
-  - python -c "import ccc"; coverage run -m pytest -v
-# - python -c "import ccc"; coverage run -m pytest -v --pep8
+  - python -c "import ccc"; coverage run -m pytest -v --pep8
 
 after_success:
   - codecov

--- a/ccc/calcfunctions.py
+++ b/ccc/calcfunctions.py
@@ -62,11 +62,11 @@ def dbsl(Y, b, bonus, r):
     Y_star = Y * (1 - (1 / b))
     z = (
         bonus + ((1 - bonus) * (((beta / (beta + r)) *
-                                 (1 - np.exp(-1 * (beta + r) * Y_star)))
-                                + ((np.exp(-1 * beta * Y_star) /
-                                    ((Y - Y_star) * r)) *
-                                   (np.exp(-1 * r * Y_star) -
-                                    np.exp(-1 * r * Y))))))
+                                 (1 - np.exp(-1 * (beta + r) * Y_star))) +
+                                ((np.exp(-1 * beta * Y_star) /
+                                  ((Y - Y_star) * r)) *
+                                 (np.exp(-1 * r * Y_star) -
+                                  np.exp(-1 * r * Y))))))
     return z
 
 

--- a/ccc/calculator.py
+++ b/ccc/calculator.py
@@ -569,8 +569,7 @@ class Calculator():
                          (base_tab['major_asset_group'] == item)]
                 [output_variable + '_mix'].values[0])
             reform_out_list.append(
-                reform_tab[(reform_tab['tax_treat'] == 'corporate')
-                           &
+                reform_tab[(reform_tab['tax_treat'] == 'corporate') &
                            (reform_tab['major_asset_group'] == item)]
                 [output_variable + '_mix'].values[0])
             diff_out_list.append(
@@ -721,8 +720,7 @@ class Calculator():
                          (base_tab['major_industry'] == item)]
                 [output_variable + '_mix'].values[0])
             reform_out_list.append(
-                reform_tab[(reform_tab['tax_treat'] == 'corporate')
-                           &
+                reform_tab[(reform_tab['tax_treat'] == 'corporate') &
                            (reform_tab['major_industry'] == item)]
                 [output_variable + '_mix'].values[0])
             diff_out_list.append(
@@ -1532,8 +1530,8 @@ class Calculator():
                    # change things on all axes
                    **PLOT_FORMATS)
         p.add_layout(Title(
-            text=('Marginal Effective Tax Rates on Corporate Investments'
-                  + ' in Equipment'), **TITLE_FORMATS), 'above')
+            text=('Marginal Effective Tax Rates on Corporate Investments' +
+                  ' in Equipment'), **TITLE_FORMATS), 'above')
 
         hover = p.select(dict(type=HoverTool))
         hover.tooltips = [('Asset', ' @asset_name (@hover)')]

--- a/ccc/get_taxcalc_rates.py
+++ b/ccc/get_taxcalc_rates.py
@@ -153,8 +153,8 @@ def get_rates(baseline=False, start_year=DEFAULT_START_YEAR, reform={},
         tau_nc[year - start_year] = (
             (((mtr_iit_schC * np.abs(calc1.array("e00900p"))) +
               (mtr_iit_schE * np.abs(calc1.array("e02000") -
-                                     calc1.array("e26270")))
-              + (mtr_iit_PT * np.abs(calc1.array("e26270")))) *
+                                     calc1.array("e26270"))) +
+              (mtr_iit_PT * np.abs(calc1.array("e26270")))) *
              pos_ti * calc1.array("s006")).sum() /
             ((np.abs(calc1.array("e00900p")) +
               np.abs(calc1.array("e02000") - calc1.array("e26270")) +

--- a/ccc/parameters.py
+++ b/ccc/parameters.py
@@ -101,8 +101,8 @@ class Specification(taxcalc.Parameters):
 
         g_scg = ((1 / self.Y_scg) *
                  np.log(((1 - self.tau_scg) *
-                         np.exp((self.inflation_rate
-                                 + self.m * self.E_c) * self.Y_scg)) +
+                         np.exp((self.inflation_rate +
+                                 self.m * self.E_c) * self.Y_scg)) +
                         self.tau_scg) - self.inflation_rate)
         g_lcg = ((1 / self.Y_lcg) *
                  np.log(((1 - self.tau_lcg) *
@@ -183,8 +183,8 @@ class Specification(taxcalc.Parameters):
         else:
             # keep debt and equity financing ratio the same even though now
             # entity level tax that might now favor debt
-            self.s['nc']['mix'] = (self.f_nc * s_nc_d + (1 - self.f_nc)
-                                   * s_c_e)
+            self.s['nc']['mix'] = (self.f_nc * s_nc_d +
+                                   (1 - self.f_nc) * s_c_e)
             self.s['c']['e'] = s_c_e
         self.tax_methods = {'DB 200%': 2.0, 'DB 150%': 1.5, 'SL': 1.0,
                             'Economic': 1.0, 'Expensing': 1.0}
@@ -230,10 +230,11 @@ class Specification(taxcalc.Parameters):
                 `PARAM: YEAR-VALUE-DICTIONARY` pairs
 
             raise_errors (boolean):
-                if True (the default), raises ValueError when `parameter_errors`
-                    exists; if False, does not raise ValueError when
-                    `parameter_errors` exists and leaves error handling
-                    to caller of the update_specification method.
+                if True (the default), raises ValueError when
+                   `parameter_errors` exists;
+                if False, does not raise ValueError when
+                   `parameter_errors` exists and leaves error handling
+                   to caller of the update_specification method.
 
         Returns:
             None

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,4 +4,5 @@ testpaths =
 markers =
     pep8
 pep8ignore =
+    ccc/calcfunctions.py E501
     ccc/controls_callback_script.py E501

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+testpaths =
+    ccc
+markers =
+    pep8
+pep8ignore =
+    ccc/controls_callback_script.py E501

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[tool:pytest]
-testpaths = ccc


### PR DESCRIPTION
This pull request shows how to run the PEP8 code-style checks automatically for each GItHub check-in.  
It also shows how to use the `pep8ignore` directive in the new `pytest.ini` file to customize the nature of the PEP8 testing by file.

I didn't know enough about the Sphinx LaTeX equations in `calcfunctions.py`file.  If the equations can be continued on a second or third or fourth line, then they could be reformatted and the `ccc/calcfunctions.py E501` line in the `pytest.ini` file could be removed.