### PR TITLE
Use conda instead of pip install from repo

### DIFF
--- a/compconfig/install.sh
+++ b/compconfig/install.sh
@@ -1,2 +1,1 @@
-conda install -c pslmodels -c conda-forge taxcalc setuptools "paramtools>=0.5.4" pip
-pip install git+https://github.com/PSLmodels/Cost-of-Capital-Calculator.git
+conda install -c pslmodels -c conda-forge ccc taxcalc setuptools "paramtools>=0.5.4" pip


### PR DESCRIPTION
This PR updates the `compconfig/install.sh` script so that CCC is installed using conda instead of pip installing the package from the git repository.