### PR TITLE
use depth of 1 for toc tree

### DIFF
--- a/docs/source/public_api.rst
+++ b/docs/source/public_api.rst
@@ -13,7 +13,7 @@ There is also a link to the source code for each documented member.
 
 
 .. toctree::
-   :maxdepth: 4
+   :maxdepth: 1
    :caption: API
 
    calcfunctions


### PR DESCRIPTION
Try to improve formatting of sphinx docs.