### PR TITLE
Bokeh dependency

### DIFF
--- a/compconfig/install.sh
+++ b/compconfig/install.sh
@@ -1,1 +1,1 @@
-conda install -c pslmodels -c conda-forge ccc taxcalc setuptools "paramtools>=0.5.4" pip
+conda install -c pslmodels -c conda-forge ccc taxcalc setuptools "bokeh>=1.2.0" "paramtools>=0.5.4" pip

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -9,6 +9,7 @@ requirements:
   build:
     - python
     - "taxcalc>=2.4.2"
+    - "bokeh>=1.2.0"
     - "paramtools>=0.7.1"
     - setuptools
     - xlrd

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ dependencies:
 - python
 - "taxcalc>=2.4.2"
 - "paramtools>=0.7.1"
+- "bokeh>=1.2.0"
 - setuptools
 - pip
 - xlrd

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ config = {
     'packages': ['ccc'],
     'include_package_data': True,
     'name': 'ccc',
-    'install_requires': ['numpy', 'pandas', 'taxcalc', 'xlrd'],
+    'install_requires': [],
     'classifiers': [
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',


### PR DESCRIPTION
This PR updates the package building files to specify the bokeh must be at least version 1.2.  Previously, CCC relied on TC's bokeh version, but TC specifies bokeh version 0.13 or greater and sometimes conda installs that version and not the newest.  This PR resolved such issues.