### PR TITLE
Fix bug in COMP functions

### DIFF
--- a/compconfig/compconfig/functions.py
+++ b/compconfig/compconfig/functions.py
@@ -65,7 +65,7 @@ def validate_inputs(meta_param_dict, adjustment, errors_warnings):
 
 def run_model(meta_param_dict, adjustment):
     '''
-    Initiliazes classes from CCC that compute the model under
+    Initializes classes from CCC that compute the model under
     different policies.  Then calls function get output objects.
     '''
     meta_params = MetaParams()
@@ -74,12 +74,13 @@ def run_model(meta_param_dict, adjustment):
         data = retrieve_puf(AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
     else:
         data = "cps"
-    params = Specification(year=meta_params.year, call_tc=True,
+    params = Specification(year=meta_params.year, call_tc=False,
                            data=data)
-    params.adjust(adjustment["ccc"])
     assets = Assets()
     calc1 = Calculator(params, assets)
-    params2 = Specification(year=meta_params.year)
+    params2 = Specification(year=meta_params.year, call_tc=False,
+                            data=data)
+    params2.update_specification(adjustment["ccc"])
     calc2 = Calculator(params2, assets)
     comp_dict = comp_output(calc1, calc2)
 

--- a/compconfig/compconfig/functions.py
+++ b/compconfig/compconfig/functions.py
@@ -110,14 +110,14 @@ def comp_output(calc1, calc2, out_var='mettr'):
             },
             {
               "media_type": "table",
-              "title":  out_var + "Summary Table",
+              "title":  out_var.upper() + " Summary Table",
               "data": html_table
             },
           ],
         "downloadable": [
             {
               "media_type": "CSV",
-              "title": out_var + "Summary Table",
+              "title": out_var.upper() + " Summary Table",
               "data": out_table.to_csv()
             }
           ]

--- a/compconfig/compconfig/tests/test_functions.py
+++ b/compconfig/compconfig/tests/test_functions.py
@@ -1,5 +1,6 @@
 from compdevkit import FunctionsTest
-
+import pandas as pd
+import io
 from compconfig import functions
 
 
@@ -12,3 +13,10 @@ def test_get_parameters():
         bad_adjustment={"ccc": {"CIT_rate": -0.1}}
     )
     ta.test()
+
+
+def test_param_effect():
+    adjustment = {"ccc": {"CIT_rate": 0.35}}
+    comp_dict = functions.run_model({}, adjustment)
+    df = pd.read_csv(io.StringIO(comp_dict['downloadable'][0]['data']))
+    assert df.loc[0, 'Change from Baseline (pp)'] != 0


### PR DESCRIPTION
The COMP `run_model` function was using the `adjust` method and not the `update_specification` method and therefore parameter updates were not being properly reflected.  This PR fixes that bug and adds a test to verify changes in parameters produce changes in output.