### PR TITLE
Parameters for CS

### DIFF
--- a/ccc/default_parameters.json
+++ b/ccc/default_parameters.json
@@ -851,7 +851,7 @@
     },
     "interest_deduct_haircut_corp": {
         "title": "Haircut on interest deductibility for corporate entities",
-        "description": "Haircut on interest deductibility (fraction of interest not deductible) for C corporations.",
+        "description": "Haircut on interest deductibility (fraction of interest not deductible) for C corporations.  Default of 0% because current law says limit is 30% of adjusted taxable income and the default assumption is that this is not binding for the marginal investment.",
         "section_1": "Deductions and Limitations on Financing",
         "notes": "This parameter gives the fraction of interest payments that are not allowable as deductions against income for C corporations.",
         "type": "float",

--- a/cs-config/cs_config/functions.py
+++ b/cs-config/cs_config/functions.py
@@ -125,9 +125,25 @@ def run_model(meta_param_dict, adjustment):
     iit_mods = convert_adj(adjustment[
         "Individual and Payroll Tax Parameters"],
                            meta_params.year.tolist())
+    filtered_ccc_params = {}
+    # filter out CCC params that will not change between baeline and
+    # reform runs (These are the Household Savings Behavior and
+    # Economic Assumptions)
+    constant_param_list = [
+        'omega_scg', 'omega_lcg', 'omega_xcg', 'alpha_c_e_ft',
+        'alpha_c_e_td', 'alpha_c_e_nt', 'alpha_c_d_ft', 'alpha_c_d_td',
+        'alpha_c_d_nt', 'alpha_nc_d_ft', 'alpha_nc_d_td',
+        'alpha_nc_d_nt', 'alpha_h_d_ft', 'alpha_h_d_td', 'alpha_h_d_nt',
+        'Y_td', 'Y_scg', 'Y_lcg', 'gamma', 'E_c', 'inflation_rate',
+        'nominal_interest_rate']
+    filtered_ccc_params = OrderedDict()
+    for k, v in adjustment['Business Tax Parameters'].items():
+        if k in constant_param_list:
+            filtered_ccc_params[k] = v
     # Baseline CCC calculator
     params = Specification(year=meta_params.year, call_tc=False,
                            iit_reform={}, data=data)
+    params.update_specification(filtered_ccc_params)
     assets = Assets()
     calc1 = Calculator(params, assets)
     # Reform CCC calculator - includes TC adjustments

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
 - python
 - "taxcalc>=2.4.2"
-- "paramtools>=0.7.1"
+- "paramtools>=0.10.1"
 - "bokeh>=1.2.0"
 - setuptools
 - pip
@@ -16,3 +16,5 @@ dependencies:
 - pycodestyle
 - pylint
 - coverage
+- pip:
+  - cs-kit


### PR DESCRIPTION
This PR filters the parameters on CS that should remain constant between the baseline and reform.

The PR also adds more to the description of the interest deduction haircut parameter to note how current law is handled (per Issue #285).