### PR TITLE
Bump Bokeh requirement to 1.4.0

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -9,7 +9,7 @@ requirements:
   build:
     - python
     - "taxcalc>=2.4.2"
-    - "bokeh>=1.2.0"
+    - "bokeh>=1.4.0"
     - "paramtools>=0.7.1"
     - setuptools
     - xlrd

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
 - python
 - "taxcalc>=2.4.2"
 - "paramtools>=0.10.1"
-- "bokeh>=1.2.0"
+- "bokeh>=1.4.0"
 - setuptools
 - pip
 - xlrd


### PR DESCRIPTION
In preparing [Tax-Calculator #2391](https://github.com/PSLmodels/Tax-Calculator/pull/2391), I found that Bokeh introduced the `legend_label` attribute (used in a few methods in `ccc/calculator.py`) in v1.4.0

cc @jdebacker