### PR TITLE
Add more output to C/S app

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,4 @@
 [run]
 omit =
     ccc/tests/*
+    cs-config/*

--- a/cs-config/cs_config/functions.py
+++ b/cs-config/cs_config/functions.py
@@ -161,8 +161,10 @@ def comp_output(calc1, calc2, out_var='mettr'):
     '''
     Function to create output for the COMP platform
     '''
-    out_table = calc1.summary_table(calc2, output_variable=out_var,
-                                    output_type='csv')
+    baseln_assets_df = calc1.calc_by_asset()
+    reform_assets_df = calc2.calc_by_asset()
+    baseln_industry_df = calc1.calc_by_industry()
+    reform_industry_df = calc2.calc_by_industry()
     html_table = calc1.summary_table(calc2, output_variable=out_var,
                                      output_type='html')
     plt1 = calc1.grouped_bar(calc2, output_variable=out_var,
@@ -201,8 +203,23 @@ def comp_output(calc1, calc2, out_var='mettr'):
         "downloadable": [
             {
               "media_type": "CSV",
-              "title": out_var.upper() + " Summary Table",
-              "data": out_table.to_csv()
+              "title": "Baseline Results by Asset",
+              "data": baseln_assets_df.to_csv(float_format='%.5f')
+            },
+            {
+              "media_type": "CSV",
+              "title": "Reform Results by Asset",
+              "data": reform_assets_df.to_csv(float_format='%.5f')
+            },
+            {
+              "media_type": "CSV",
+              "title": "Baseline Results by Industry",
+              "data": baseln_industry_df.to_csv(float_format='%.5f')
+            },
+            {
+              "media_type": "CSV",
+              "title": "Reform Results by Industry",
+              "data": reform_industry_df.to_csv(float_format='%.5f')
             }
           ]
         }

--- a/cs-config/cs_config/functions.py
+++ b/cs-config/cs_config/functions.py
@@ -174,7 +174,7 @@ def comp_output(calc1, calc2, out_var='mettr'):
                              group_by_asset=False,
                              include_title=True)
     plot_data2 = json_item(plt2)
-    plt3 = calc1.range_plot(calc2, output_variable='metr',
+    plt3 = calc1.range_plot(calc2, output_variable='mettr',
                             include_title=True)
     plot_data3 = json_item(plt3)
     comp_dict = {
@@ -196,7 +196,7 @@ def comp_output(calc1, calc2, out_var='mettr'):
             },
             {
               "media_type": "bokeh",
-              "title": plt3.title._property_values['text'],
+              "title": "Marginal Effective Total Tax Rates by Method of Financing",
               "data": plot_data3
             }
           ],

--- a/cs-config/cs_config/functions.py
+++ b/cs-config/cs_config/functions.py
@@ -165,21 +165,38 @@ def comp_output(calc1, calc2, out_var='mettr'):
                                     output_type='csv')
     html_table = calc1.summary_table(calc2, output_variable=out_var,
                                      output_type='html')
-    plt = calc1.grouped_bar(calc2, output_variable=out_var,
+    plt1 = calc1.grouped_bar(calc2, output_variable=out_var,
+                             include_title=True)
+    plot_data1 = json_item(plt1)
+    plt2 = calc1.grouped_bar(calc2, output_variable=out_var,
+                             group_by_asset=False,
+                             include_title=True)
+    plot_data2 = json_item(plt2)
+    plt3 = calc1.range_plot(calc2, output_variable='metr',
                             include_title=True)
-    plot_data = json_item(plt)
+    plot_data3 = json_item(plt3)
     comp_dict = {
         "renderable": [
-            {
-              "media_type": "bokeh",
-              "title": plt.title._property_values['text'],
-              "data": plot_data
-            },
             {
               "media_type": "table",
               "title":  out_var.upper() + " Summary Table",
               "data": html_table
             },
+            {
+              "media_type": "bokeh",
+              "title": plt1.title._property_values['text'],
+              "data": plot_data1
+            },
+            {
+              "media_type": "bokeh",
+              "title": plt2.title._property_values['text'],
+              "data": plot_data2
+            },
+            {
+              "media_type": "bokeh",
+              "title": plt3.title._property_values['text'],
+              "data": plot_data3
+            }
           ],
         "downloadable": [
             {

--- a/cs-config/cs_config/inputs.py
+++ b/cs-config/cs_config/inputs.py
@@ -1,0 +1,104 @@
+from typing import Union
+
+from paramtools import Parameters
+
+
+def convert_policy_defaults(meta_params: Parameters, policy_params: Parameters):
+    """
+    Convert defaults for taxcalc's Policy class to work with C/S.
+    """
+    policy_params.array_first = False
+    policy_params.uses_extend_func = False
+    init = policy_params.dump()
+    defaults = convert_sections(init)
+    defaults = convert_data_source(defaults, meta_params.data_source)
+    defaults = convert_indexed_to_checkbox(defaults)
+    return defaults
+
+
+def convert_policy_adjustment(policy_adjustment: dict):
+    """
+    Convert adjutments for taxcalc's Policy class to work with C/S.
+    """
+    return convert_checkbox(policy_adjustment)
+
+
+def convert_behavior_adjustment(adj):
+    """
+    Convert a C/S behavioral adjustment to work with the Behavioral-Responses
+    package
+    """
+    behavior = {}
+    if adj:
+        for param, value in adj.items():
+            behavior[param] = value[0]["value"]
+    return behavior
+
+
+def convert_checkbox(policy_params):
+    """
+    Replace param_checkbox with param-indexed.
+    """
+    params = {}
+    # drop checkbox parameters.
+    for param, data in policy_params.items():
+        if param.endswith("checkbox"):
+            base_param = param.split("_checkbox")[0]
+            params[f"{base_param}-indexed"] = data
+        else:
+            params[param] = data
+
+    return params
+
+
+def convert_data_source(defaults: dict, data_source: Union["PUF", "CPS"]):
+    """
+    Handle parameters that are incompatible with the selected dataset.
+    """
+    new_defaults = {}
+    for param, data in defaults.items():
+        if (
+            defaults.get("compatible_data") is not None
+            and not defaults["compatible_data"][data_source.lower()]
+        ):
+            new_defaults[param] = dict(data, value=[])
+        else:
+            new_defaults[param] = data
+    return new_defaults
+
+
+def convert_indexed_to_checkbox(defaults: dict):
+    """
+    C/S expects there to be a checkbox attribute instead of
+    indexed in the defaults.
+    """
+    new_defaults = {}
+    for param, data in defaults.items():
+
+        if param == "schema":
+            data["additional_members"]["checkbox"] = dict(
+                data["additional_members"]["indexed"]
+            )
+            new_defaults["schema"] = data
+
+        elif data["indexable"] and data.get("indexed", None) is True:
+            new_defaults[param] = dict(data, checkbox= True)
+
+        elif data["indexable"] and not data.get("indexed", None) is False:
+            new_defaults[param] = dict(data, checkbox=False)
+
+        else:
+            new_defaults[param] = data
+
+    return new_defaults
+
+
+def convert_sections(defaults):
+    """
+    Drop parameters that are missing section_1.
+    """
+    filtered_pol_params = {}
+    for k, v in defaults.items():
+        if k == "schema" or v.get("section_1", False):
+            filtered_pol_params[k] = v
+    return filtered_pol_params

--- a/cs-config/cs_config/tests/test_functions.py
+++ b/cs-config/cs_config/tests/test_functions.py
@@ -1,5 +1,6 @@
 from cs_kit import CoreTestFunctions
 import pandas as pd
+import numpy as np
 import io
 from cs_config import functions
 
@@ -19,5 +20,6 @@ def test_param_effect():
     adjustment = {"Business Tax Parameters": {"CIT_rate": 0.35},
                   "Individual and Payroll Tax Parameters": {}}
     comp_dict = functions.run_model({}, adjustment)
-    df = pd.read_csv(io.StringIO(comp_dict['downloadable'][0]['data']))
-    assert df.loc[0, 'Change from Baseline (pp)'] != 0
+    df1 = pd.read_csv(io.StringIO(comp_dict['downloadable'][0]['data']))
+    df2 = pd.read_csv(io.StringIO(comp_dict['downloadable'][1]['data']))
+    assert max(np.absolute(df1['rho_mix']-df2['rho_mix'])) > 0

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 testpaths =
     ccc
+    cs-config/cs_config/tests
 markers =
     pep8
 pep8ignore =


### PR DESCRIPTION
This PR adds more output to the Compute Studio app for CCC.  The output page will now include 3 plots and one table.  The download will not have 3 csv files so that users can have the most detailed output from the model to look at changes by industry and asset.