### PR TITLE
PSL catalog links

### DIFF
--- a/PSL_catalog.json
+++ b/PSL_catalog.json
@@ -37,7 +37,7 @@
     "user_documentation": {
         "start_header": null,
         "end_header": null,
-        "data": "<a href=\"https://github.com/PSLmodels/Cost-of-Capital-Calculator/blob/master/docs/CCCC_Guide.pdf\">https://github.com/PSLmodels/Cost-of-Capital-Calculator/blob/master/docs/CCCC_Guide.pdf</a>",
+        "data": "<a href=\"https://pslmodels.github.io/Cost-of-Capital-Calculator/\">https://pslmodels.github.io/Cost-of-Capital-Calculator/</a>",
         "source": null,
         "type": "html"
     },

--- a/PSL_catalog.json
+++ b/PSL_catalog.json
@@ -135,7 +135,7 @@
     "core_maintainers": {
         "start_header": null,
         "end_header": null,
-        "data": "<ul><li>Jason DeBacker</li></ul>",
+        "data": "<ul><li><a href=\"http://jasondebacker.com\">Jason DeBacker</a></li></ul>",
         "source": null,
         "type": "html"
     },


### PR DESCRIPTION
This PR updates links to CCC documentation on the [PSL Catalog page](https://www.pslmodels.org/Catalog/index.html).