### PR TITLE
Add cs2tc to cs-config/install.sh

### DIFF
--- a/cs-config/install.sh
+++ b/cs-config/install.sh
@@ -1,1 +1,2 @@
 conda install -c pslmodels -c conda-forge ccc taxcalc setuptools "bokeh>=1.2.0" "paramtools>=0.5.4" pip
+pip install cs2tc


### PR DESCRIPTION
@jdebacker This should fix this error:

```
______________________ ERROR collecting test_functions.py ______________________
ImportError while importing test module '/home/test_functions.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/conda/lib/python3.7/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
test_functions.py:5: in <module>
    from cs_config import functions
/opt/conda/lib/python3.7/site-packages/cs_config/__init__.py:1: in <module>
    from .functions import *
/opt/conda/lib/python3.7/site-packages/cs_config/functions.py:14: in <module>
    from cs2tc import convert_policy_adjustment
E   ModuleNotFoundError: No module named 'cs2tc'
```