### PR TITLE
CS year validator

### DIFF
--- a/cs-config/cs_config/functions.py
+++ b/cs-config/cs_config/functions.py
@@ -45,6 +45,27 @@ class MetaParams(paramtools.Parameters):
         }
     }
 
+    def dump(self, *args, **kwargs):
+        """
+        This method extends the default ParamTools dump method by
+        swapping the when validator for a choice validator. This is
+        required because C/S does not yet implement the when validator.
+        """
+        data = super().dump(*args, **kwargs)
+        if self.data_source == "CPS":
+            data["year"]["validators"] = {
+                "choice": {
+                    "choices": list(range(2014, TC_LAST_YEAR))
+                }
+            }
+        else:
+            data["year"]["validators"] = {
+                "choice": {
+                    "choices": list(range(2013, TC_LAST_YEAR))
+                }
+            }
+        return data
+
 
 def get_inputs(meta_params_dict):
     '''
@@ -91,7 +112,11 @@ def validate_inputs(meta_param_dict, adjustment, errors_warnings):
     '''
     Validates user inputs for parameters
     '''
-    # ccc doesn't look at meta_param_dict for validating inputs.
+    # Validate meta parameter inputs
+    meta_params = MetaParameters()
+    meta_params.adjust(meta_params_dict, raise_errors=False)
+    errors_warnings["policy"]["errors"].update(meta_params.errors)
+    # Validate CCC parameter inputs
     params = Specification()
     params.adjust(adjustment["Business Tax Parameters"],
                   raise_errors=False)

--- a/cs-config/cs_config/functions.py
+++ b/cs-config/cs_config/functions.py
@@ -113,9 +113,9 @@ def validate_inputs(meta_param_dict, adjustment, errors_warnings):
     Validates user inputs for parameters
     '''
     # Validate meta parameter inputs
-    meta_params = MetaParameters()
-    meta_params.adjust(meta_params_dict, raise_errors=False)
-    errors_warnings["policy"]["errors"].update(meta_params.errors)
+    meta_params = MetaParams()
+    meta_params.adjust(meta_param_dict, raise_errors=False)
+    errors_warnings["Business Tax Parameters"]["errors"].update(meta_params.errors)
     # Validate CCC parameter inputs
     params = Specification()
     params.adjust(adjustment["Business Tax Parameters"],

--- a/cs-config/cs_config/tests/test_functions.py
+++ b/cs-config/cs_config/tests/test_functions.py
@@ -5,6 +5,26 @@ import io
 from cs_config import functions
 
 
+def test_start_year_with_data_source():
+    """
+    Test interaction between PUF and CPS data sources and the start year.
+    """
+    data = functions.get_inputs({"data_source": "PUF"})
+    assert data["meta_parameters"]["year"]["validators"]["choice"]["choices"][0] == 2013
+    data = functions.get_inputs({"data_source": "CPS"})
+    assert data["meta_parameters"]["year"]["validators"]["choice"]["choices"][0] == 2014
+
+    ew = {
+        "policy": {"errors": {}, "warnings": {}},
+        "behavior": {"errors": {}, "warnings": {}},
+    }
+    res = functions.validate_inputs(
+        {"data_source": "CPS", "year": 2013},
+        {"policy": {}, "behavior": {}}, ew
+    )
+    assert res["errors_warnings"]["policy"]["errors"].get("year")
+
+
 class TestFunctions1(CoreTestFunctions):
     get_version = functions.get_version
     get_inputs = functions.get_inputs

--- a/cs-config/cs_config/tests/test_functions.py
+++ b/cs-config/cs_config/tests/test_functions.py
@@ -15,14 +15,16 @@ def test_start_year_with_data_source():
     assert data["meta_parameters"]["year"]["validators"]["choice"]["choices"][0] == 2014
 
     ew = {
-        "policy": {"errors": {}, "warnings": {}},
-        "behavior": {"errors": {}, "warnings": {}},
+        # "meta_parameters": {"errors": {}, "warnings": {}},
+        "Business Tax Parameters": {"errors": {}, "warnings": {}},
+        "Individual and Payroll Tax Parameters": {"errors": {}, "warnings": {}}
     }
     res = functions.validate_inputs(
         {"data_source": "CPS", "year": 2013},
-        {"policy": {}, "behavior": {}}, ew
+        {"Business Tax Parameters": {},
+         "Individual and Payroll Tax Parameters": {}}, ew
     )
-    assert res["errors_warnings"]["policy"]["errors"].get("year")
+    assert res["errors_warnings"]["Business Tax Parameters"]["errors"].get("year")
 
 
 class TestFunctions1(CoreTestFunctions):

--- a/cs-config/cs_config/tests/test_functions.py
+++ b/cs-config/cs_config/tests/test_functions.py
@@ -10,21 +10,27 @@ def test_start_year_with_data_source():
     Test interaction between PUF and CPS data sources and the start year.
     """
     data = functions.get_inputs({"data_source": "PUF"})
-    assert data["meta_parameters"]["year"]["validators"]["choice"]["choices"][0] == 2013
+    assert (
+        data["meta_parameters"]["year"]["validators"]["choice"]
+        ["choices"][0] == 2013)
     data = functions.get_inputs({"data_source": "CPS"})
-    assert data["meta_parameters"]["year"]["validators"]["choice"]["choices"][0] == 2014
+    assert (
+        data["meta_parameters"]["year"]["validators"]["choice"]
+        ["choices"][0] == 2014)
 
     ew = {
-        # "meta_parameters": {"errors": {}, "warnings": {}},
         "Business Tax Parameters": {"errors": {}, "warnings": {}},
-        "Individual and Payroll Tax Parameters": {"errors": {}, "warnings": {}}
+        "Individual and Payroll Tax Parameters":
+        {"errors": {}, "warnings": {}}
     }
     res = functions.validate_inputs(
         {"data_source": "CPS", "year": 2013},
         {"Business Tax Parameters": {},
          "Individual and Payroll Tax Parameters": {}}, ew
     )
-    assert res["errors_warnings"]["Business Tax Parameters"]["errors"].get("year")
+    assert (
+        res["errors_warnings"]["Business Tax Parameters"]
+        ["errors"].get("year"))
 
 
 class TestFunctions1(CoreTestFunctions):

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
 - python
 - "taxcalc>=3.1.0"
-- "paramtools>=0.14.2"
+- "paramtools>=0.18.0"
 - "bokeh>=1.4.0"
 - setuptools
 - pip


### PR DESCRIPTION
This PR adds logic to validate the start year conditional on the dataset chosen in the C/S web application.  A test of this logic is also added.