### PR TITLE
Delete no longer used `requirements.txt` file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-pandas
-numpy
-os
-numpydoc


### PR DESCRIPTION
This PR removes the `requirements.txt` file since it is no longer used. I noticed this when building a new version of the CCC app for Compute Studio.