### PR TITLE
Install ccc from conda-forge on Compute Studio

### DIFF
--- a/cs-config/install.sh
+++ b/cs-config/install.sh
@@ -1,2 +1,1 @@
-conda install -c pslmodels -c conda-forge ccc taxcalc setuptools "bokeh>=1.2.0" "paramtools>=0.5.4" pip
-pip install cs2tc
+conda install -c conda-forge ccc


### PR DESCRIPTION
This installs `ccc` from conda-forge instead of the pslmodels conda channel.