### PR TITLE
Add exception for non-positive cost of capital

### DIFF
--- a/ccc/calcfunctions.py
+++ b/ccc/calcfunctions.py
@@ -3,6 +3,8 @@ import pandas as pd
 from ccc.constants import TAX_METHODS
 from ccc.utils import str_modified
 
+ENFORCE_CHECKS = True
+
 
 def update_depr_methods(df, p, dp):
     '''
@@ -184,6 +186,14 @@ def eq_coc(delta, z, w, u, inv_tax_credit, pi, r):
     '''
     rho = (((r - pi + delta) / (1 - u)) *
            (1 - inv_tax_credit - u * z) + w - delta)
+
+    if ENFORCE_CHECKS and np.any(rho <= 0):
+        print('Error raised')
+        err = ('The cost of capital is less than or equal to zero in ' +
+               'at least one case. Please try alternative parameter ' +
+               'values to ensure a cost of capital that is positive.')
+        raise RuntimeError(err)
+
     return rho
 
 

--- a/ccc/tests/test_calcfunctions.py
+++ b/ccc/tests/test_calcfunctions.py
@@ -272,6 +272,14 @@ def test_eq_coc(delta, z, w, u, inv_tax_credit, pi, r, expected_val):
     assert(np.allclose(test_val, expected_val))
 
 
+def test_eq_coc_exception1():
+    '''
+    Raise exception for non-positive cost of capital
+    '''
+    with pytest.raises(RuntimeError):
+        assert cf.eq_coc(0.05, 1.0, 0.0, 0.28, 1.0, 0.02, 0.04)
+
+
 u = np.array([0.3, 0, 0.3, 0, 0.3, 0])
 phi = np.array([0.33, 0.33, 0.33, 0.33, 0.33, 0.33])
 Y_v = np.array([8, 8, 8, 8, 8, 8])


### PR DESCRIPTION
A cost of capital that is non-positive does not make sense (the result would be infinite profits through infinite investment).  This PR adds a `RuntimeError` that is raised if the parameters used result in a non-positive cost of capital.

cc @hdoupe -- this addresses a recent error seen in Compute Studio.