### PR TITLE
Updates for new cs kit

### DIFF
--- a/cs-config/cs_config/helpers.py
+++ b/cs-config/cs_config/helpers.py
@@ -14,6 +14,8 @@ from ccc.utils import TC_LAST_YEAR
 AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID")
 AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY")
 
+PUF_S3_FILE_NAME = "puf.20210720.csv.gz"
+
 POLICY_SCHEMA = {
     "labels": {
         "year": {
@@ -71,7 +73,7 @@ def retrieve_puf(
         print("Reading puf from S3 bucket.")
         fs = S3FileSystem(key=AWS_ACCESS_KEY_ID,
                           secret=AWS_SECRET_ACCESS_KEY,)
-        with fs.open("s3://ospc-data-files/puf.csv.gz") as f:
+        with fs.open(f"s3://ospc-data-files/{PUF_S3_FILE_NAME}") as f:
             # Skips over header from top of file.
             puf_df = pd.read_csv(f, compression="gzip")
         return puf_df

--- a/environment.yml
+++ b/environment.yml
@@ -17,5 +17,5 @@ dependencies:
 - coverage
 - pip:
   - jupyter-book>=0.9.1
-  - cs-kit
+  - "cs-kit>=1.16.8"
   - cs2tc


### PR DESCRIPTION
This PR makes a couple modifications for the `cs-config` files to work with the lates `cs-kit`.

@hdoupe -- It looks like the latest `cs-kit` will fix the `bokeh` plot rendering issues on C/S:

```
 cs_kit.exceptions.CSKitError: "Bokeh outputs must be created with json_item. Reference: https://docs.compute.studio/publish/outputs/#bokeh"
```

Is that correct?