### PR TITLE
Improve variable and parameter name consistency

### DIFF
--- a/ccc/calculator.py
+++ b/ccc/calculator.py
@@ -103,7 +103,7 @@ class Calculator():
 
         '''
         dfs = {'c': df[df['tax_treat'] == 'corporate'].copy(),
-               'nc': df[df['tax_treat'] == 'non-corporate'].copy()}
+               'pt': df[df['tax_treat'] == 'non-corporate'].copy()}
         # separate into corp and non-corp dataframe here
         for t in self.__p.entity_list:
             for f in self.__p.financing_list:
@@ -137,7 +137,7 @@ class Calculator():
             self.__assets.df, self.__p, self.__dp)
         dfs = {'c': self.__assets.df[
                self.__assets.df['tax_treat'] == 'corporate'].copy(),
-               'nc': self.__assets.df[
+               'pt': self.__assets.df[
                self.__assets.df['tax_treat'] == 'non-corporate'].copy()}
         # separate into corp and non-corp dataframe here
         for t in self.__p.entity_list:
@@ -1149,7 +1149,7 @@ class Calculator():
 
         data_sources = {}
         for i, df_i in enumerate(list_df):
-            for t in ['c', 'nc']:
+            for t in ['c', 'pt']:
                 if t == 'c':
                     df = df_i.drop(df_i[df_i.tax_treat !=
                                         'corporate'].index)
@@ -1386,10 +1386,10 @@ class Calculator():
         # add buttons
         controls_callback = CustomJS(
             args=data_sources, code=CONTROLS_CALLBACK_SCRIPT)
-        c_nc_buttons = RadioButtonGroup(
+        c_pt_buttons = RadioButtonGroup(
             labels=['Corporate', 'Noncorporate'], active=0)
-        c_nc_buttons.js_on_change('value', controls_callback)
-        controls_callback.args['c_nc_buttons'] = c_nc_buttons
+        c_pt_buttons.js_on_change('value', controls_callback)
+        controls_callback.args['c_pt_buttons'] = c_pt_buttons
         format_buttons = RadioButtonGroup(
             labels=['Baseline', 'Reform', 'Change'], active=0)
         format_buttons.js_on_change('value', controls_callback)
@@ -1411,7 +1411,7 @@ class Calculator():
         tabs = Tabs(tabs=[tab, tab2])
         layout = gridplot(
             children=[[tabs],
-                      [c_nc_buttons, interest_buttons],
+                      [c_pt_buttons, interest_buttons],
                       [format_buttons, type_buttons]]
         )
         # layout = gridplot([p, p2], ncols=2, plot_width=250, plot_height=250)

--- a/ccc/controls_callback_script.py
+++ b/ccc/controls_callback_script.py
@@ -2,20 +2,20 @@ CONTROLS_CALLBACK_SCRIPT = """
 var equip_data = equip_source.data;
 var struc_data = struc_source.data;
 
-var c_nc_button = c_nc_buttons.active;
+var c_pt_button = c_pt_buttons.active;
 var format_button = format_buttons.active;
 var type_button = type_buttons.active;
 var interest_button = interest_buttons.active;
 
-var n_nc_str, format_str, type_str, interest_button
-var c_nc_title, interest_title
+var n_pt_str, format_str, type_str, interest_button
+var c_pt_title, interest_title
 
-if (c_nc_button == 0) {
-    c_nc_str = '_c';
-    c_nc_title = 'Corporate';
-} else if (c_nc_button == 1) {
-    c_nc_str = '_nc';
-    c_nc_title = 'Noncorporate';
+if (c_pt_button == 0) {
+    c_pt_str = '_c';
+    c_pt_title = 'Corporate';
+} else if (c_pt_button == 1) {
+    c_pt_str = '_pt';
+    c_pt_title = 'Noncorporate';
 }
 
 if (format_button == 0) {
@@ -62,22 +62,22 @@ if (interest_button == 0) {
     interest_title = 'Net Present Value of Depreciation'
 }
 
-equip_plot.title.text = interest_title + ' on ' + c_nc_title +
+equip_plot.title.text = interest_title + ' on ' + c_pt_title +
     ' Investments in Equipment';
-struc_plot.title.text = interest_title + ' on ' + c_nc_title +
+struc_plot.title.text = interest_title + ' on ' + c_pt_title +
     ' Investments in Structures';
 
 var new_equip_data = eval(format_str + 'equipment' + interest_str +
-    type_str + c_nc_str).data
+    type_str + c_pt_str).data
 var new_struc_data = eval(format_str + 'structure' + interest_str +
-    type_str + c_nc_str).data
+    type_str + c_pt_str).data
 
 equip_data['size'] = []
 equip_data['rate'] = []
 equip_data['hover'] = []
 equip_data['short_category'] = []
 for (var i = 0; i < new_equip_data['size'].length; i++) {
-    equip_data['size'].push(new_equip_data['size' + c_nc_str][i]);
+    equip_data['size'].push(new_equip_data['size' + c_pt_str][i]);
     equip_data['rate'].push(new_equip_data['rate'][i]);
     equip_data['hover'].push(new_equip_data['hover'][i]);
     equip_data['short_category'].push(new_equip_data['short_category'][i]);

--- a/ccc/default_parameters.json
+++ b/ccc/default_parameters.json
@@ -702,7 +702,7 @@
         "title": "Allowance for non-corporate equity",
         "description": "Allowance for non-corporate equity (fraction of equity deductible).",
         "section_1": "Deductions and Limitations on Financing",
-        "notes": "This parameter gives the allowance for non-corporate equity (ACE). Only relevant if there is an entity-level tax on pass-through businesses (PT_entity_tax_ind=True).  Under an ACE system, companies can deduct a notional interest on their equity.  The default rate used in Cost-of-Capital-Calculator is the nominal interest rate on corporate debt.  Moving this parameter up from zero allows the corporate to have partial to full deductibility of the notional interest on equity.",
+        "notes": "This parameter gives the allowance for non-corporate equity (ACE). Only relevant if there is an entity-level tax on pass-through businesses (pt_entity_tax_ind=True).  Under an ACE system, companies can deduct a notional interest on their equity.  The default rate used in Cost-of-Capital-Calculator is the nominal interest rate on corporate debt.  Moving this parameter up from zero allows the corporate to have partial to full deductibility of the notional interest on equity.",
         "type": "float",
         "value": [
             {

--- a/ccc/default_parameters.json
+++ b/ccc/default_parameters.json
@@ -698,7 +698,7 @@
             }
         }
     },
-    "ace_nc": {
+    "ace_pt": {
         "title": "Allowance for non-corporate equity",
         "description": "Allowance for non-corporate equity (fraction of equity deductible).",
         "section_1": "Deductions and Limitations on Financing",
@@ -736,7 +736,7 @@
             }
         }
     },
-    "interest_deduct_haircut_corp": {
+    "interest_deduct_haircut_c": {
         "title": "Haircut on interest deductibility for corporate entities",
         "description": "Haircut on interest deductibility (fraction of interest not deductible) for C corporations.  Default of 0% because current law says limit is 30% of adjusted taxable income and the default assumption is that this is not binding for the marginal investment.",
         "section_1": "Deductions and Limitations on Financing",
@@ -755,7 +755,7 @@
             }
         }
     },
-    "interest_deduct_haircut_PT": {
+    "interest_deduct_haircut_pt": {
         "title": "Haircut on interest deductibility for pass-through entities",
         "description": "Haircut on interest deductibility (fraction of interest not deductible) for pass-through entities.",
         "section_1": "Deductions and Limitations on Financing",
@@ -846,7 +846,7 @@
         ],
         "validators": {}
     },
-    "tau_nc": {
+    "tau_pt": {
         "title": "Effective marginal tax rate on business income to pass-through business owners",
         "description": "Effective marginal tax rate on business income to pass-through business owners.",
         "section_1": "Individual Level Taxes",
@@ -1697,7 +1697,7 @@
             }
         }
     },
-    "f_nc": {
+    "f_pt": {
         "title": "Fraction of non-corporate investment financed by debt",
         "description": "Fraction of non-corporate investment financed by debt.",
         "section_1": "Accounting and Financial Policy",
@@ -1896,7 +1896,7 @@
             }
         }
     },
-    "alpha_nc_d_ft": {
+    "alpha_pt_d_ft": {
         "title": "Fraction of non-corporate debt held in fully-taxable accounts",
         "description": "Fraction of non-corporate debt held in fully-taxable accounts.",
         "section_1": "Individual Level Taxes",
@@ -1916,7 +1916,7 @@
             }
         }
     },
-    "alpha_nc_d_td": {
+    "alpha_pt_d_td": {
         "title": "Fraction of non-corporate debt held in tax-deferred accounts",
         "description": "Fraction of non-corporate debt held in tax-deferred accounts.",
         "section_1": "Individual Level Taxes",
@@ -1936,7 +1936,7 @@
             }
         }
     },
-    "alpha_nc_d_nt": {
+    "alpha_pt_d_nt": {
         "title": "Fraction of non-corporate debt held in non-taxable accounts",
         "description": "Fraction of non-corporate debt held in non-taxable accounts.",
         "section_1": "Individual Level Taxes",

--- a/ccc/default_parameters.json
+++ b/ccc/default_parameters.json
@@ -73,11 +73,11 @@
             }
         }
     },
-    "PT_entity_tax_ind": {
+    "pt_entity_tax_ind": {
         "title": "Pass-through businss entity-level tax indicator",
         "description": "Indicator variable indicating whether or not there is an entity-level tax on pass-through businesses. This tax is levied on entity-level profits.  Owners also pay individual income taxes on the distributions.",
         "section_1": "Business-entity level taxes",
-        "notes": "Note that is this indicator is True, then the METR calculation for pass-through businesses will represent the effects of the entity-level tax and not the indvidiual-level tax.  This is becaue the METR represents the effective tax rate from the first layer of taxation.  The statutory rate on pass-through entities is set with the PT_entity_tax_rate parameter.",
+        "notes": "Note that is this indicator is True, then the METR calculation for pass-through businesses will represent the effects of the entity-level tax and not the indvidiual-level tax.  This is becaue the METR represents the effective tax rate from the first layer of taxation.  The statutory rate on pass-through entities is set with the pt_entity_tax_rate parameter.",
         "type": "bool",
         "value": [
             {
@@ -87,7 +87,7 @@
         ],
         "validators": {}
     },
-    "PT_entity_tax_rate": {
+    "pt_entity_tax_rate": {
         "title": "Statutory income tax rate on pass-through business income levied at the entity level",
         "description": "Statutory income tax rate on pass-through business income levied at the entity level.",
         "section_1": "Business-entity level taxes",

--- a/ccc/get_taxcalc_rates.py
+++ b/ccc/get_taxcalc_rates.py
@@ -92,7 +92,7 @@ def get_rates(baseline=False, start_year=DEFAULT_START_YEAR, reform={},
     rates_dict = {'tau_div': 'e00650', 'tau_int': 'e00300',
                   'tau_scg': 'p22250', 'tau_lcg': 'p23250'}
     individual_rates = {
-        'tau_nc': np.zeros(array_size), 'tau_div': np.zeros(array_size),
+        'tau_pt': np.zeros(array_size), 'tau_div': np.zeros(array_size),
         'tau_int': np.zeros(array_size), 'tau_scg': np.zeros(array_size),
         'tau_lcg': np.zeros(array_size), 'tau_td': np.zeros(array_size),
         'tau_h': np.zeros(array_size)}
@@ -123,7 +123,7 @@ def get_rates(baseline=False, start_year=DEFAULT_START_YEAR, reform={},
         [mtr_fica_prop, mtr_iit_prop, mtr_combined_prop] =\
             calc1.mtr('e18500')
         pos_ti = calc1.array("c04800") > 0
-        individual_rates['tau_nc'][year - start_year] = (
+        individual_rates['tau_pt'][year - start_year] = (
             (((mtr_iit_schC * np.abs(calc1.array("e00900p"))) +
               (mtr_iit_schE * np.abs(calc1.array("e02000") -
                                      calc1.array("e26270"))) +

--- a/ccc/parameters.py
+++ b/ccc/parameters.py
@@ -1,4 +1,4 @@
-'pt'import os
+import os
 import paramtools
 import marshmallow as ma
 
@@ -77,18 +77,18 @@ class Specification(paramtools.Parameters):
 
         # Set rate of 1st layer of taxation on investment income
         self.u = {'c': self.CIT_rate}
-        if not self.PT_entity_tax_ind.all():
+        if not self.pt_entity_tax_ind.all():
             self.u['pt'] = self.tau_pt
         else:
-            self.u['pt'] = self.PT_entity_tax_rate
+            self.u['pt'] = self.pt_entity_tax_rate
         E_dict = {'c': self.E_c, 'pt': E_pt}
 
         # Allowance for Corporate Equity
         ace_dict = {'c': self.ace_c, 'pt': self.ace_pt}
 
         # Limitation on interest deduction
-        int_haircut_dict = {'c': self.interest_deduct_haircut_corp,
-                            'pt': self.interest_deduct_haircut_PT}
+        int_haircut_dict = {'c': self.interest_deduct_haircut_c,
+                            'pt': self.interest_deduct_haircut_pt}
         # Debt financing ratios
         f_dict = {'c': {'mix': self.f_c, 'd': 1.0, 'e': 0.0},
                   'pt': {'mix': self.f_pt, 'd': 1.0, 'e': 0.0}}
@@ -101,7 +101,7 @@ class Specification(paramtools.Parameters):
 
         # if no entity level taxes on pass-throughs, ensure mettr and metr
         # on non-corp entities the same
-        if not self.PT_entity_tax_ind:
+        if not self.pt_entity_tax_ind:
             for f in self.financing_list:
                 r_prime['pt'][f] = self.s['pt'][f] + self.inflation_rate
         # if entity level tax, assume distribute earnings at same rate corps

--- a/ccc/parameters.py
+++ b/ccc/parameters.py
@@ -1,4 +1,4 @@
-import os
+'pt'import os
 import paramtools
 import marshmallow as ma
 
@@ -48,7 +48,7 @@ class Specification(paramtools.Parameters):
             # Find individual income tax rates from Tax-Calculator
             indiv_rates = get_rates(self.baseline, self.year,
                                     self.iit_reform, self.data)
-            self.tau_nc = indiv_rates['tau_nc']
+            self.tau_pt = indiv_rates['tau_pt']
             self.tau_div = indiv_rates['tau_div']
             self.tau_int = indiv_rates['tau_int']
             self.tau_scg = indiv_rates['tau_scg']
@@ -64,7 +64,7 @@ class Specification(paramtools.Parameters):
 
         '''
         self.financing_list = ['mix', 'd', 'e']
-        self.entity_list = ['c', 'nc']
+        self.entity_list = ['c', 'pt']
 
         # If new_view, then don't assume don't pay out any dividends
         # This becuase under new view, equity investments are financed
@@ -73,25 +73,25 @@ class Specification(paramtools.Parameters):
             self.m = 1
 
         # Get after-tax return to savers
-        self.s, E_nc = pf.calc_s(self)
+        self.s, E_pt = pf.calc_s(self)
 
         # Set rate of 1st layer of taxation on investment income
         self.u = {'c': self.CIT_rate}
         if not self.PT_entity_tax_ind.all():
-            self.u['nc'] = self.tau_nc
+            self.u['pt'] = self.tau_pt
         else:
-            self.u['nc'] = self.PT_entity_tax_rate
-        E_dict = {'c': self.E_c, 'nc': E_nc}
+            self.u['pt'] = self.PT_entity_tax_rate
+        E_dict = {'c': self.E_c, 'pt': E_pt}
 
         # Allowance for Corporate Equity
-        ace_dict = {'c': self.ace_c, 'nc': self.ace_nc}
+        ace_dict = {'c': self.ace_c, 'pt': self.ace_pt}
 
         # Limitation on interest deduction
         int_haircut_dict = {'c': self.interest_deduct_haircut_corp,
-                            'nc': self.interest_deduct_haircut_PT}
+                            'pt': self.interest_deduct_haircut_PT}
         # Debt financing ratios
         f_dict = {'c': {'mix': self.f_c, 'd': 1.0, 'e': 0.0},
-                  'nc': {'mix': self.f_nc, 'd': 1.0, 'e': 0.0}}
+                  'pt': {'mix': self.f_pt, 'd': 1.0, 'e': 0.0}}
 
         # Compute firm discount factors
         self.r = pf.calc_r(self, f_dict, int_haircut_dict, E_dict, ace_dict)
@@ -103,7 +103,7 @@ class Specification(paramtools.Parameters):
         # on non-corp entities the same
         if not self.PT_entity_tax_ind:
             for f in self.financing_list:
-                r_prime['nc'][f] = self.s['nc'][f] + self.inflation_rate
+                r_prime['pt'][f] = self.s['pt'][f] + self.inflation_rate
         # if entity level tax, assume distribute earnings at same rate corps
         # distribute dividends and these are taxed at dividends tax rate
         # (which seems likely).  Also implicitly assumed that if entity
@@ -112,8 +112,8 @@ class Specification(paramtools.Parameters):
         else:
             # keep debt and equity financing ratio the same even though now
             # entity level tax that might now favor debt
-            self.s['nc']['mix'] = (self.f_nc * self.s['nc']['d'] +
-                                   (1 - self.f_nc) * self.s['c']['e'])
+            self.s['pt']['mix'] = (self.f_pt * self.s['pt']['d'] +
+                                   (1 - self.f_pt) * self.s['c']['e'])
         self.r_prime = r_prime
 
         # Map string tax methods into multiple of declining balance

--- a/ccc/paramfunctions.py
+++ b/ccc/paramfunctions.py
@@ -284,7 +284,7 @@ def calc_s(p):
     s_pt = p.f_pt * s_pt_d + (1 - p.f_pt) * s_pt_e
     # Return the after-tax rates of return on all types of investments
     s_dict = {'c': {'mix': s_c, 'd': s_c_d, 'e': s_c_e},
-              'nc': {'mix': s_pt, 'd': s_pt_d, 'e': s_pt_e}}
+              'pt': {'mix': s_pt, 'd': s_pt_d, 'e': s_pt_e}}
 
     return s_dict, E_pt
 

--- a/ccc/paramfunctions.py
+++ b/ccc/paramfunctions.py
@@ -227,7 +227,7 @@ def calc_s(p):
             * s_dict (dict): dictionary of s for investments in
                 corporate and pass-through businesses and by type of
                 financing
-            * E_nc (scalar): required pre-tax return on pass-through
+            * E_pt (scalar): required pre-tax return on pass-through
                 investments
 
     '''
@@ -246,10 +246,10 @@ def calc_s(p):
                       p.nominal_interest_rate, p.inflation_rate)
     # The after-tax return on non-corporate debt investments made
     # through tax deferred accounts
-    s_nc_d_td = s_c_d_td
+    s_pt_d_td = s_c_d_td
     # The after-tax return on non-corporate debt investments
-    s_nc_d = calc_s__d(s_nc_d_td, p.alpha_nc_d_ft, p.alpha_nc_d_td,
-                       p.alpha_nc_d_nt, p.tau_int, p.tau_w,
+    s_pt_d = calc_s__d(s_pt_d_td, p.alpha_pt_d_ft, p.alpha_pt_d_td,
+                       p.alpha_pt_d_nt, p.tau_int, p.tau_w,
                        p.nominal_interest_rate, p.inflation_rate)
     # The after-tax real, annualized return on short-term capital gains
     g_scg = calc_g__g(p.Y_scg, p.tau_scg, p.m, p.E_c, p.inflation_rate)
@@ -276,17 +276,17 @@ def calc_s(p):
     # equity combined)
     s_c = p.f_c * s_c_d + (1 - p.f_c) * s_c_e
     # The required rate of return on non-corporate investments
-    E_nc = s_c_e
+    E_pt = s_c_e
     # The after-tax rate of return on non-corporate equity investments
-    s_nc_e = E_nc - p.tau_w
+    s_pt_e = E_pt - p.tau_w
     # The after-tax return on non-corporate investments (all - debt and
     # equity combined)
-    s_nc = p.f_nc * s_nc_d + (1 - p.f_nc) * s_nc_e
+    s_pt = p.f_pt * s_pt_d + (1 - p.f_pt) * s_pt_e
     # Return the after-tax rates of return on all types of investments
     s_dict = {'c': {'mix': s_c, 'd': s_c_d, 'e': s_c_e},
-              'nc': {'mix': s_nc, 'd': s_nc_d, 'e': s_nc_e}}
+              'nc': {'mix': s_pt, 'd': s_pt_d, 'e': s_pt_e}}
 
-    return s_dict, E_nc
+    return s_dict, E_pt
 
 
 def calc_r(p, f_dict, int_haircut_dict, E_dict, ace_dict):

--- a/ccc/tests/test_parameters.py
+++ b/ccc/tests/test_parameters.py
@@ -43,16 +43,16 @@ def test_new_view():
     assert spec.m == 1
 
 
-def test_PT_tax():
+def test_pt_tax():
     cyr = 2020
     spec = Specification(year=cyr)
     new_spec_dict = {
-        'PT_entity_tax_ind': True,
-        'PT_entity_tax_rate': 0.44
+        'pt_entity_tax_ind': True,
+        'pt_entity_tax_rate': 0.44
     }
     spec.update_specification(new_spec_dict)
-    assert spec.PT_entity_tax_ind
-    assert spec.u['nc'] == 0.44
+    assert spec.pt_entity_tax_ind
+    assert spec.u['pt'] == 0.44
 
 
 def test_update_specification_with_json():
@@ -100,13 +100,13 @@ def test_update_bad_revsions2():
     # Pick a category for depreciation that is out of bounds
     revs = {
         'profit_rate': 0.5,
-        'PT_entity_tax_rate': 1.2}
+        'pt_entity_tax_rate': 1.2}
     spec.update_specification(revs, raise_errors=False)
     assert len(spec.errors) > 0
-    first_line = spec.errors['PT_entity_tax_rate'][0]
+    first_line = spec.errors['pt_entity_tax_rate'][0]
     print('First line = ', first_line)
     expected_first_line = (
-        'PT_entity_tax_rate 1.2 > max 1.0 '
+        'pt_entity_tax_rate 1.2 > max 1.0 '
     )
     assert first_line == expected_first_line
 

--- a/ccc/tests/test_paramfunctions.py
+++ b/ccc/tests/test_paramfunctions.py
@@ -170,7 +170,7 @@ def test_calc_rprime(p, expected_dict):
     Test of the calculation of the after-tax rate of return function
     '''
     f_dict = {'c': {'mix': p.f_c, 'd': 1.0, 'e': 0.0},
-              pt: {'mix': p.f_pt, 'd': 1.0, 'e': 0.0}}
+              'pt': {'mix': p.f_pt, 'd': 1.0, 'e': 0.0}}
     E_dict = {'c': p.E_c, 'pt': 0.07}
     test_dict = pf.calc_r_prime(p, f_dict, E_dict)
 

--- a/ccc/tests/test_paramfunctions.py
+++ b/ccc/tests/test_paramfunctions.py
@@ -93,44 +93,44 @@ revisions = {'Y_td': 8, 'Y_scg': 2, 'Y_lcg': 7, 'tau_td': 0.2,
              'E_c': 0.09, 'nominal_interest_rate': 0.08,
              'inflation_rate': 0.02, 'alpha_c_d_ft': 0.3,
              'alpha_c_d_td': 0.5, 'alpha_c_d_nt': 0.2,
-             'alpha_nc_d_ft': 0.5, 'alpha_nc_d_td': 0.4,
-             'alpha_nc_d_nt': 0.1, 'alpha_c_e_ft': 0.6,
+             'alpha_pt_d_ft': 0.5, 'alpha_pt_d_td': 0.4,
+             'alpha_pt_d_nt': 0.1, 'alpha_c_e_ft': 0.6,
              'alpha_c_e_td': 0.3, 'alpha_c_e_nt': 0.1, 'omega_scg': 0.7,
              'omega_lcg': 0.1, 'omega_xcg': 0.2, 'f_c': 0.32,
-             'f_nc': 0.42}
+             'f_pt': 0.42}
 p.update_specification(revisions)
 expected_dict = {
     'c': {'mix': 0.042792929, 'd': 0.029696442, 'e': 0.048955981},
-    'nc': {'mix': 0.027511674, 'd': 0.025517154, 'e': 0.028955981}}
+    'pt': {'mix': 0.027511674, 'd': 0.025517154, 'e': 0.028955981}}
 
 
 @pytest.mark.parametrize('entity_type,p,expected_dict',
                          [('c', p, expected_dict),
-                          ('nc', p, expected_dict)],
+                          ('pt', p, expected_dict)],
                          ids=['Corporate', 'Pass-Throughs'])
 def test_calc_s(entity_type, p, expected_dict):
     '''
     Test of the paramfunctions.calc_s function
     '''
-    test_dict, test_E_nc = pf.calc_s(p)
+    test_dict, test_E_pt = pf.calc_s(p)
 
     for k, v in test_dict[entity_type].items():
         assert(np.allclose(v, expected_dict[entity_type][k]))
 
-    assert(np.allclose(test_E_nc, 0.048955981))
+    assert(np.allclose(test_E_pt, 0.048955981))
 
 
 p = Specification()
 revisions = {
-    'f_c': 0.4, 'f_nc': 0.2, 'interest_deduct_haircut_corp': 0.0,
-    'interest_deduct_haircut_PT': 0.0, 'ace_c': 0.0, 'ace_nc': 0.0,
-    'CIT_rate': 0.25, 'tau_nc': 0.22, 'nominal_interest_rate': 0.05,
+    'f_c': 0.4, 'f_pt': 0.2, 'interest_deduct_haircut_c': 0.0,
+    'interest_deduct_haircut_pt': 0.0, 'ace_c': 0.0, 'ace_pt': 0.0,
+    'CIT_rate': 0.25, 'tau_pt': 0.22, 'nominal_interest_rate': 0.05,
     'inflation_rate': 0.02, 'E_c': 0.08}
 p.update_specification(revisions)
 expected_r_dict = {
     'c': {'mix': np.array([0.075]), 'd': np.array([0.0375]),
           'e': np.array([0.1])},
-    'nc': {'mix': np.array([0.0798]), 'd': np.array([0.039]),
+    'pt': {'mix': np.array([0.0798]), 'd': np.array([0.039]),
            'e': np.array([0.09])}}
 
 
@@ -142,12 +142,12 @@ def test_calc_r(p, expected_dict):
     Test of the calculation of the discount rate function
     '''
     f_dict = {'c': {'mix': p.f_c, 'd': 1.0, 'e': 0.0},
-              'nc': {'mix': p.f_nc, 'd': 1.0, 'e': 0.0}}
-    int_haircut_dict = {'c': p.interest_deduct_haircut_corp,
-                        'nc': p.interest_deduct_haircut_PT}
-    E_dict = {'c': p.E_c, 'nc': 0.07}
+              'pt': {'mix': p.f_pt, 'd': 1.0, 'e': 0.0}}
+    int_haircut_dict = {'c': p.interest_deduct_haircut_c,
+                        'pt': p.interest_deduct_haircut_pt}
+    E_dict = {'c': p.E_c, 'pt': 0.07}
     print('E dict = ', E_dict)
-    ace_dict = {'c': p.ace_c, 'nc': p.ace_nc}
+    ace_dict = {'c': p.ace_c, 'pt': p.ace_pt}
     test_dict = pf.calc_r(p, f_dict, int_haircut_dict, E_dict, ace_dict)
 
     for k, v in test_dict.items():
@@ -158,7 +158,7 @@ def test_calc_r(p, expected_dict):
 expected_rprime_dict = {
     'c': {'mix': np.array([0.08]), 'd': np.array([0.05]),
           'e': np.array([0.1])},
-    'nc': {'mix': np.array([0.082]), 'd': np.array([0.05]),
+    'pt': {'mix': np.array([0.082]), 'd': np.array([0.05]),
            'e': np.array([0.09])}}
 
 
@@ -170,8 +170,8 @@ def test_calc_rprime(p, expected_dict):
     Test of the calculation of the after-tax rate of return function
     '''
     f_dict = {'c': {'mix': p.f_c, 'd': 1.0, 'e': 0.0},
-              'nc': {'mix': p.f_nc, 'd': 1.0, 'e': 0.0}}
-    E_dict = {'c': p.E_c, 'nc': 0.07}
+              pt: {'mix': p.f_pt, 'd': 1.0, 'e': 0.0}}
+    E_dict = {'c': p.E_c, 'pt': 0.07}
     test_dict = pf.calc_r_prime(p, f_dict, E_dict)
 
     for k, v in test_dict.items():

--- a/docs/book/content/CCC_guide.md
+++ b/docs/book/content/CCC_guide.md
@@ -590,11 +590,11 @@ One may alter the macroeconomic assumptions regarding rates of interest and infl
 
 *Individual Income Taxation*: `Cost of Capital Calculator` has the ability to allow for changes in individual income tax rates on pass-through business income, interest, dividends, and capital gains. In addition, policies affecting the deductibility of property taxes or mortgage interest affect the after-tax costs of owner-occupied housing.  To find the effect of such policy changes on the marginal investor, `Cost of Capital Calculator `interacts with OSPC's `Tax-Calculator`. Once the reform policies are specified, the `Tax-Calculator` computes the marginal tax rates on non-corporate business income, dividend income, interest income, capital gains income, and tax-deferred retirement account income.  The rates we apply to the "marginal investor" in the model are then computed as:
 
-* $\tau_{nc}$ = weighted average marginal tax rate on ordinary, non-corporate business income (weighted by amount of non-corp business income)
+* $\tau_{pt}$ = weighted average marginal tax rate on ordinary, non-corporate business income (weighted by amount of non-corporate business income)
 * $\tau_{div}$ = weighted average marginal tax rate on dividend income (weighted by amount of dividend income received)
 * $\tau_{int}$ = weighted average of marginal tax rate on interest income (weighted by amount of interest income received)
-* $\tau_{scg}$ = weighted average of marginal tax rate on short term capital gains (weighted by amount of short term capital gains received)
-* $\tau_{lcg}$ = weighted average of marginal tax rate on long term capital gains (weighted by amount of long term capital gains received)
+* $\tau_{scg}$ = weighted average of marginal tax rate on short-term capital gains (weighted by amount of short-term capital gains received)
+* $\tau_{lcg}$ = weighted average of marginal tax rate on long-term capital gains (weighted by amount of long-term capital gains received)
 * $\tau_{xcg}$ = weighted average of marginal tax rate on capital gains held until death (weighted by amount of total capital gains received)
 * $\tau_{td}$ = weighted average of marginal tax rate on pension distributions (weighted by the amount of pension distributions)
 * $\tau_{h}$ = weighted average marginal tax rate on mortgage interest and property taxes (weighted by amounts of these deductions)


### PR DESCRIPTION
This PR attempts to improve variable name consistency by replacing `nc` with `pt` and `corp` with `c`.