### PR TITLE
Allow for more flexibility in individual income tax micro data input

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           pytest -m 'not needs_puf' --cov=./ --cov-report=xml
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && contains(github.repository, 'PSLmodels/Cost-of-Capital-Calculator')
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -34,7 +34,7 @@ jobs:
         shell: bash -l {0}
         working-directory: ./
         run: |
-          pytest -m 'not needs_puf' --cov=./ --cov-report=xml
+          pytest -m 'not needs_puf and not needs_tmd' --cov=./ --cov-report=xml
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && contains(github.repository, 'PSLmodels/Cost-of-Capital-Calculator')
         uses: codecov/codecov-action@v4

--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ Results will change as the underlying models improve. A fundamental reason for a
 
 
 ## Citing the Cost-of-Capital-Calculator Model
-Cost-of-Capital-Calculator (Version 1.4.0)[Source code], https://github.com/PSLmodels/Cost-of-Capital-Calculator
+Cost-of-Capital-Calculator (Version 1.4.1)[Source code], https://github.com/PSLmodels/Cost-of-Capital-Calculator

--- a/ccc/__init__.py
+++ b/ccc/__init__.py
@@ -6,4 +6,4 @@ from ccc.parameters import *
 from ccc.data import *
 from ccc.calculator import *
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"

--- a/ccc/get_taxcalc_rates.py
+++ b/ccc/get_taxcalc_rates.py
@@ -53,15 +53,9 @@ def get_calculator(
     else:
         records1 = Records()  # pragma: no cover
 
-    if baseline:
-        if (
-            baseline_policy
-        ):  # if something other than current law policy baseline
-            update_policy(policy1, baseline_policy)
-
-    if not baseline:
-        if baseline_policy:  # update baseline policy to layer reform on top
-            update_policy(policy1, baseline_policy)
+    if baseline_policy:  # if something other than current law policy baseline
+        update_policy(policy1, baseline_policy)
+    if reform:  # if there is a reform
         update_policy(policy1, reform)
 
     # the default set up increments year to 2013

--- a/ccc/get_taxcalc_rates.py
+++ b/ccc/get_taxcalc_rates.py
@@ -5,7 +5,6 @@ from ccc.utils import DEFAULT_START_YEAR, TC_LAST_YEAR, RECORDS_START_YEAR
 
 
 def get_calculator(
-    baseline,
     calculator_start_year,
     baseline_policy=None,
     reform=None,
@@ -18,7 +17,6 @@ def get_calculator(
     This function creates the tax calculator object for the microsim
 
     Args:
-        baseline (bool): `True` if baseline tax policy
         calculator_start_year (integer): first year of budget window
         baseline_policy (dictionary): IIT baseline parameters
         reform (dictionary): IIT reform parameters
@@ -73,20 +71,28 @@ def get_calculator(
 
 
 def get_rates(
-    baseline=False,
     start_year=DEFAULT_START_YEAR,
     baseline_policy=None,
     reform={},
     data="cps",
+    gfactors=None,
+    weights=None,
+    records_start_year=RECORDS_START_YEAR,
 ):
     """
     This function computes weighted average marginal tax rates using
     micro data from the tax calculator
 
     Args:
-        baseline (bool): `True` if baseline tax policy, `False` if reform
-        start_year (integer): first year of budget window
+        start_year (integer): start year for the simulations
+        baseline_policy (dict): baseline parameters
         reform (dict): reform parameters
+        data (string or Pandas DataFrame): path to file or DataFrame
+            for Tax-Calculator Records object (optional)
+        gfactors (Tax-Calculator GrowFactors object): grow factors
+        weights (str): path to weights file for Tax-Calculator
+            Records object
+        records_start_year (integer): the start year for the microdata
 
     Returns:
         individual_rates (dict): individual income (IIT+payroll)
@@ -94,11 +100,13 @@ def get_rates(
 
     """
     calc1 = get_calculator(
-        baseline=baseline,
         calculator_start_year=start_year,
         baseline_policy=baseline_policy,
         reform=reform,
         data=data,
+        gfactors=None,
+        weights=None,
+        records_start_year=RECORDS_START_YEAR,
     )
 
     # running all the functions and calculates taxes

--- a/ccc/get_taxcalc_rates.py
+++ b/ccc/get_taxcalc_rates.py
@@ -15,6 +15,11 @@ def get_calculator(
 ):
     """
     This function creates the tax calculator object for the microsim
+    model.
+
+    Note: gfactors and weights are only used if provide custom data
+    path or file with those gfactors and weights.  Otherwise, the
+    model defaults to those gfactors and weights from Tax-Calculator.
 
     Args:
         calculator_start_year (integer): first year of budget window
@@ -22,6 +27,7 @@ def get_calculator(
         reform (dictionary): IIT reform parameters
         data (string or Pandas DataFrame): path to file or DataFrame
             for Tax-Calculator Records object (optional)
+        gfactors (str or DataFrame): grow factors to extrapolate data
         weights (DataFrame): weights DataFrame for Tax-Calculator
             Records object (optional)
         records_start_year (integer): the start year for the data and
@@ -42,6 +48,12 @@ def get_calculator(
         records1.p23250 = (1 - 0.06587) * records1.e01100
         # set total capital gains to zero
         records1.e01100 = np.zeros(records1.e01100.shape[0])
+    elif data is None or "puf" in data:  # pragma: no cover
+        print("Using PUF")
+        records1 = Records()
+    elif data is not None and "tmd" in data:  # pragma: no cover
+        print("Using TMD")
+        records1 = Records.tmd_constructor()
     elif data is not None:  # pragma: no cover
         print("Data is ", data)
         print("Weights are ", weights)
@@ -52,8 +64,8 @@ def get_calculator(
             weights=weights,
             start_year=records_start_year,
         )  # pragma: no cover
-    else:
-        records1 = Records()  # pragma: no cover
+    else:  # pragma: no cover
+        raise ValueError("Please provide data or use CPS, PUF, or TMD.")
 
     if baseline_policy:  # if something other than current law policy baseline
         update_policy(policy1, baseline_policy)

--- a/ccc/get_taxcalc_rates.py
+++ b/ccc/get_taxcalc_rates.py
@@ -53,7 +53,7 @@ def get_calculator(
         records1 = Records()
     elif data is not None and "tmd" in data:  # pragma: no cover
         print("Using TMD")
-        records1 = Records.tmd_constructor()
+        records1 = Records.tmd_constructor("tmd.csv.gz")
     elif data is not None:  # pragma: no cover
         print("Data is ", data)
         print("Weights are ", weights)

--- a/ccc/get_taxcalc_rates.py
+++ b/ccc/get_taxcalc_rates.py
@@ -1,6 +1,6 @@
 # imports
 import numpy as np
-from taxcalc import Policy, Records, Calculator
+from taxcalc import Policy, Records, Calculator, GrowFactors
 from ccc.utils import DEFAULT_START_YEAR, TC_LAST_YEAR, RECORDS_START_YEAR
 
 
@@ -34,6 +34,7 @@ def get_calculator(
     # create a calculator
     policy1 = Policy()
     if data is not None and "cps" in data:
+        print("Using CPS")
         records1 = Records.cps_constructor()
         # impute short and long term capital gains if using CPS data
         # in 2012 SOI data 6.587% of CG as short-term gains
@@ -42,6 +43,9 @@ def get_calculator(
         # set total capital gains to zero
         records1.e01100 = np.zeros(records1.e01100.shape[0])
     elif data is not None:  # pragma: no cover
+        print("Data is ", data)
+        print("Weights are ", weights)
+        print("Records start year is ", records_start_year)
         records1 = Records(
             data=data,
             gfactors=gfactors,
@@ -106,7 +110,7 @@ def get_rates(
         data=data,
         gfactors=None,
         weights=None,
-        records_start_year=RECORDS_START_YEAR,
+        records_start_year=records_start_year,
     )
 
     # running all the functions and calculates taxes

--- a/ccc/parameters.py
+++ b/ccc/parameters.py
@@ -41,7 +41,10 @@ class Specification(paramtools.Parameters):
         self.data = data
         # initialize parameter values from JSON
         self.ccc_initialize(
-            call_tc=call_tc, gfactors=gfactors, weights=weights
+            call_tc=call_tc,
+            gfactors=gfactors,
+            weights=weights,
+            records_start_year=records_start_year,
         )
 
     def ccc_initialize(

--- a/ccc/parameters.py
+++ b/ccc/parameters.py
@@ -40,9 +40,17 @@ class Specification(paramtools.Parameters):
         self.iit_reform = iit_reform
         self.data = data
         # initialize parameter values from JSON
-        self.ccc_initialize(call_tc=call_tc, gfactors=gfactors, weights=weights)
+        self.ccc_initialize(
+            call_tc=call_tc, gfactors=gfactors, weights=weights
+        )
 
-    def ccc_initialize(self, call_tc=False, gfactors=None, weights=None, records_start_year=RECORDS_START_YEAR):
+    def ccc_initialize(
+        self,
+        call_tc=False,
+        gfactors=None,
+        weights=None,
+        records_start_year=RECORDS_START_YEAR,
+    ):
         """
         ParametersBase reads JSON file and sets attributes to self
         Next call self.compute_default_params for further initialization
@@ -73,7 +81,7 @@ class Specification(paramtools.Parameters):
                 self.data,
                 gfactors,
                 weights,
-                records_start_year
+                records_start_year,
             )
             self.tau_pt = indiv_rates["tau_pt"]
             self.tau_div = indiv_rates["tau_div"]

--- a/ccc/tests/test_get_taxcalc_rates.py
+++ b/ccc/tests/test_get_taxcalc_rates.py
@@ -6,22 +6,21 @@ from ccc.utils import TC_LAST_YEAR
 
 
 @pytest.mark.parametrize(
-    "baseline",
-    [(True), (False)],
+    "reform",
+    [(None), ({"FICA_ss_trt": {2018: 0.125}})],
     ids=["baseline", "reform"],
 )
-def test_get_calculator_cps(baseline):
+def test_get_calculator_cps(reform):
     """
     Test the get_calculator() function
     """
     calc1 = tc.get_calculator(
-        baseline,
         2019,
         baseline_policy={"FICA_ss_trt": {2018: 0.15}},
-        reform={"FICA_ss_trt": {2018: 0.125}},
+        reform=reform,
     )
     assert calc1.current_year == 2019
-    if baseline:
+    if reform is None:
         assert calc1.policy_param("FICA_ss_trt") == 0.15
     else:
         assert calc1.policy_param("FICA_ss_trt") == 0.125
@@ -29,16 +28,15 @@ def test_get_calculator_cps(baseline):
 
 @pytest.mark.needs_puf
 @pytest.mark.parametrize(
-    "baseline,data",
-    [(True, "puf.csv"), (True, None), (False, None)],
-    ids=["baseline,data=PUF", "baseline,data=None", "reform,data=None"],
+    "data",
+    [("puf.csv"), (None)],
+    ids=["baseline,data=PUF", "baseline,data=None"],
 )
-def test_get_calculator(baseline, data):
+def test_get_calculator(data):
     """
     Test the get_calculator() function
     """
     calc1 = tc.get_calculator(
-        baseline,
         2019,
         baseline_policy={"FICA_ss_trt": {2018: 0.15}},
         reform={"FICA_ss_trt": {2018: 0.125}},
@@ -61,7 +59,6 @@ def test_get_rates():
     """
     p = Specification(year=2020)  # has default tax rates, with should equal TC
     test_dict = tc.get_rates(
-        baseline=False,
         start_year=2020,
         baseline_policy={},
         reform={},

--- a/ccc/tests/test_get_taxcalc_rates.py
+++ b/ccc/tests/test_get_taxcalc_rates.py
@@ -7,7 +7,7 @@ from ccc.utils import TC_LAST_YEAR
 
 @pytest.mark.parametrize(
     "reform",
-    [(None), ({"FICA_ss_trt": {2018: 0.125}})],
+    [(None), ({"FICA_ss_trt_employee": {2018: 0.0625}})],
     ids=["baseline", "reform"],
 )
 def test_get_calculator_cps(reform):
@@ -16,14 +16,14 @@ def test_get_calculator_cps(reform):
     """
     calc1 = tc.get_calculator(
         2019,
-        baseline_policy={"FICA_ss_trt": {2018: 0.15}},
+        baseline_policy={"FICA_ss_trt_employee": {2018: 0.075}},
         reform=reform,
     )
     assert calc1.current_year == 2019
     if reform is None:
-        assert calc1.policy_param("FICA_ss_trt") == 0.15
+        assert calc1.policy_param("FICA_ss_trt_employee") == 0.075
     else:
-        assert calc1.policy_param("FICA_ss_trt") == 0.125
+        assert calc1.policy_param("FICA_ss_trt_employee") == 0.0625
 
 
 @pytest.mark.needs_puf
@@ -38,8 +38,8 @@ def test_get_calculator_puf(data):
     """
     calc1 = tc.get_calculator(
         2019,
-        baseline_policy={"FICA_ss_trt": {2018: 0.15}},
-        reform={"FICA_ss_trt": {2018: 0.125}},
+        baseline_policy={"FICA_ss_trt_employee": {2018: 0.075}},
+        reform={"FICA_ss_trt_employee": {2018: 0.0625}},
         data=data,
     )
     assert calc1.current_year == 2019
@@ -57,8 +57,8 @@ def test_get_calculator_tmd(data):
     """
     calc1 = tc.get_calculator(
         2021,
-        baseline_policy={"FICA_ss_trt": {2021: 0.15}},
-        reform={"FICA_ss_trt": {2022: 0.125}},
+        baseline_policy={"FICA_ss_trt_employee": {2021: 0.075}},
+        reform={"FICA_ss_trt_employee": {2022: 0.0625}},
         data=data,
     )
     assert calc1.current_year == 2021

--- a/ccc/tests/test_get_taxcalc_rates.py
+++ b/ccc/tests/test_get_taxcalc_rates.py
@@ -32,7 +32,7 @@ def test_get_calculator_cps(reform):
     [("puf.csv"), (None)],
     ids=["baseline,data=PUF", "baseline,data=None"],
 )
-def test_get_calculator(data):
+def test_get_calculator_puf(data):
     """
     Test the get_calculator() function
     """
@@ -43,6 +43,25 @@ def test_get_calculator(data):
         data=data,
     )
     assert calc1.current_year == 2019
+
+
+@pytest.mark.needs_tmd
+@pytest.mark.parametrize(
+    "data",
+    [("tmd.csv")],
+    ids=["baseline,data=TMD"],
+)
+def test_get_calculator_tmd(data):
+    """
+    Test the get_calculator() function
+    """
+    calc1 = tc.get_calculator(
+        2021,
+        baseline_policy={"FICA_ss_trt": {2021: 0.15}},
+        reform={"FICA_ss_trt": {2022: 0.125}},
+        data=data,
+    )
+    assert calc1.current_year == 2021
 
 
 def test_get_calculator_exception():

--- a/ccc/tests/test_get_taxcalc_rates.py
+++ b/ccc/tests/test_get_taxcalc_rates.py
@@ -69,7 +69,7 @@ def test_get_calculator_exception():
     Test the get_calculator() function
     """
     with pytest.raises(Exception):
-        assert tc.get_calculator(True, TC_LAST_YEAR + 1)
+        assert tc.get_calculator(TC_LAST_YEAR + 1)
 
 
 def test_get_rates():

--- a/ccc/tests/test_start_years.py
+++ b/ccc/tests/test_start_years.py
@@ -12,7 +12,7 @@ def test_tc_start_year(year):
     Test that different start years work in functions calling
     Tax-Calculator
     """
-    get_rates(True, year)
+    get_rates(year)
 
 
 @pytest.mark.parametrize(

--- a/cs-config/cs_config/functions.py
+++ b/cs-config/cs_config/functions.py
@@ -7,7 +7,7 @@ from bokeh.embed import json_item
 import os
 import paramtools
 import pandas as pd
-from taxcalc import Policy, Records, Growfactors
+from taxcalc import Policy, Records, GrowFactors
 from collections import OrderedDict
 from .helpers import retrieve_puf, retrieve_tmd
 import cs2tc
@@ -209,6 +209,7 @@ def run_model(meta_param_dict, adjustment):
     elif meta_params.data_source == "CPS":
         data = "cps"
         weights = Records.PUF_WEIGHTS_FILENAME
+        records_start_year = Records.CPSCSV_YEAR
     else:
         raise ValueError(
             f"Data source '{meta_params.data_source}' is not supported."
@@ -263,7 +264,7 @@ def run_model(meta_param_dict, adjustment):
         call_tc=True,
         iit_reform=iit_mods,
         data=data,
-        gfactors=Growfactors.FILE_NAME,
+        gfactors=GrowFactors.FILE_NAME,
         weights=weights,
         records_start_year=records_start_year,
     )

--- a/cs-config/cs_config/helpers.py
+++ b/cs-config/cs_config/helpers.py
@@ -19,6 +19,9 @@ AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY", None)
 PUF_S3_FILE_LOCATION = os.environ.get(
     "PUF_S3_LOCATION", "s3://ospc-data-files/puf.20210720.csv.gz"
 )
+TMD_S3_FILE_LOCATION = os.environ.get(
+    "TMD_S3_LOCATION", "s3://ospc-data-files/puf.20210720.csv.gz"
+)
 
 POLICY_SCHEMA = {
     "labels": {
@@ -111,6 +114,43 @@ def retrieve_puf(
     else:
         warnings.warn(
             f"PUF file not available (puf_location={puf_s3_file_location}, "
+            f"has_credentials={has_credentials}, "
+            f"s3_reader_installed={s3_reader_installed})"
+        )
+        return None
+
+
+def retrieve_tmd(
+    tmd_s3_file_location=TMD_S3_FILE_LOCATION,
+    aws_access_key_id=AWS_ACCESS_KEY_ID,
+    aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
+):
+    """
+    Function for retrieving the TMD from the S3 bucket
+    """
+    s3_reader_installed = S3FileSystem is not None
+    has_credentials = (
+        aws_access_key_id is not None and aws_secret_access_key is not None
+    )
+    if tmd_s3_file_location and has_credentials and s3_reader_installed:
+        print("Reading tmd from S3 bucket.", tmd_s3_file_location)
+        fs = S3FileSystem(
+            key=AWS_ACCESS_KEY_ID,
+            secret=AWS_SECRET_ACCESS_KEY,
+        )
+        with fs.open(tmd_s3_file_location) as f:
+            # Skips over header from top of file.
+            tmd_df = pd.read_csv(f)
+        return tmd_df
+    elif Path("tmd.csv.gz").exists():
+        print("Reading tmd from tmd.csv.gz.")
+        return pd.read_csv("tmd.csv.gz", compression="gzip")
+    elif Path("tmd.csv").exists():
+        print("Reading tmd from tmd.csv.")
+        return pd.read_csv("tmd.csv")
+    else:
+        warnings.warn(
+            f"TMD file not available (tmd_location={tmd_s3_file_location}, "
             f"has_credentials={has_credentials}, "
             f"s3_reader_installed={s3_reader_installed})"
         )

--- a/cs-config/cs_config/tests/test_functions.py
+++ b/cs-config/cs_config/tests/test_functions.py
@@ -51,7 +51,7 @@ class TestFunctions1(CoreTestFunctions):
             "CIT_rate": [{"year": DEFAULT_START_YEAR, "value": 0.25}]
         },
         "Individual and Payroll Tax Parameters": {
-            "FICA_ss_trt": [{"year": DEFAULT_START_YEAR, "value": 0.14}]
+            "FICA_ss_trt_employee": [{"year": DEFAULT_START_YEAR, "value": 0.07}]
         },
     }
     bad_adjustment = {

--- a/cs-config/cs_config/tests/test_functions.py
+++ b/cs-config/cs_config/tests/test_functions.py
@@ -51,7 +51,9 @@ class TestFunctions1(CoreTestFunctions):
             "CIT_rate": [{"year": DEFAULT_START_YEAR, "value": 0.25}]
         },
         "Individual and Payroll Tax Parameters": {
-            "FICA_ss_trt_employee": [{"year": DEFAULT_START_YEAR, "value": 0.07}]
+            "FICA_ss_trt_employee": [
+                {"year": DEFAULT_START_YEAR, "value": 0.07}
+            ]
         },
     }
     bad_adjustment = {

--- a/docs/book/content/intro.md
+++ b/docs/book/content/intro.md
@@ -22,4 +22,4 @@ Results will change as the underlying models improve. A fundamental reason for a
 
 
 ## Citing the Cost-of-Capital-Calculator Model
-Cost-of-Capital-Calculator (Version 1.4.0)[Source code], https://github.com/PSLmodels/Cost-of-Capital-Calculator
+Cost-of-Capital-Calculator (Version 1.4.1)[Source code], https://github.com/PSLmodels/Cost-of-Capital-Calculator

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,8 @@ testpaths =
     cs-config/cs_config/tests
 markers =
     pep8
+    needs_puf
+    needs_tmd
 pep8ignore =
     ccc/calcfunctions.py E501
     ccc/controls_callback_script.py E501

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ except ImportError:
 with open("README.md") as f:
     longdesc = f.read()
 
-version = "1.4.0"
+version = "1.4.1"
 
 config = {
     "description": "CCC: A Cost of Capital Calculator",


### PR DESCRIPTION
This PR update `get_taxcalc_rates.py` to allow for more flexibility in the micro data file used by allowing for grow factors, weights, and start years to be passed as arguments.