### PR TITLE
Updates for Tax-Calculator >= 6.0, fix deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@ Results will change as the underlying models improve. A fundamental reason for a
 
 
 ## Citing the Cost-of-Capital-Calculator Model
-Cost-of-Capital-Calculator (Version 1.5.2)[Source code], https://github.com/PSLmodels/Cost-of-Capital-Calculator
+Cost-of-Capital-Calculator (Version 2.1.1)[Source code], https://github.com/PSLmodels/Cost-of-Capital-Calculator

--- a/ccc/__init__.py
+++ b/ccc/__init__.py
@@ -6,4 +6,4 @@ from ccc.parameters import *
 from ccc.data import *
 from ccc.calculator import *
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"

--- a/ccc/calcfunctions.py
+++ b/ccc/calcfunctions.py
@@ -36,7 +36,7 @@ def update_depr_methods(df, p, dp):
     df.replace({"bonus": p.bonus_deprec}, inplace=True)
     # Compute b
     df["b"] = df["method"]
-    df.replace({"b": TAX_METHODS}, regex=True, inplace=True)
+    df["b"] = df["b"].map(TAX_METHODS)
     # use b value of 1 if method is not in TAX_METHODS
     # NOTE: not sure why the replace method doesn't work for this method
     # Related: had to comment this out in TAX_METHODS

--- a/ccc/calcfunctions.py
+++ b/ccc/calcfunctions.py
@@ -38,7 +38,7 @@ def update_depr_methods(df, p, dp):
     df["b"] = df["method"]
     df.replace({"b": TAX_METHODS}, regex=True, inplace=True)
     # use b value of 1 if method is not in TAX_METHODS
-    # NOTE: not sure why the replae method doesn't work for this method
+    # NOTE: not sure why the replace method doesn't work for this method
     # Related: had to comment this out in TAX_METHODS
     df.loc[df["b"] == "Income Forecast", "b"] = 1.0
     # cast b as float

--- a/ccc/calculator.py
+++ b/ccc/calculator.py
@@ -53,7 +53,6 @@ from bokeh.models.widgets import RadioButtonGroup
 from bokeh.models.tickers import FixedTicker
 from bokeh.layouts import gridplot, column
 
-
 # import styles and callback
 from ccc.styles import PLOT_FORMATS, TITLE_FORMATS, RED, BLUE
 from ccc.controls_callback_script import CONTROLS_CALLBACK_SCRIPT
@@ -1340,12 +1339,10 @@ class Calculator:
         p.xaxis[0].ticker = FixedTicker(ticks=[0, 1, 2])
         # Done as a custom function instead of a categorical axis because
         # categorical axes do not work well with other features
-        p.xaxis.formatter = CustomJSTickFormatter(
-            code="""
+        p.xaxis.formatter = CustomJSTickFormatter(code="""
         var types = ["Typically Financed", "Debt Financed", "Equity Financed"]
         return types[tick]
-        """
-        )
+        """)
         p.yaxis.axis_label = VAR_DICT[output_variable]
         p.yaxis[0].formatter = NumeralTickFormatter(format="0%")
 

--- a/ccc/calculator.py
+++ b/ccc/calculator.py
@@ -216,9 +216,7 @@ class Calculator:
                             self.__p.r[t][f],
                         )
                     )
-        self.__assets.df = pd.concat(
-            dfs, ignore_index=True, sort=True
-        )
+        self.__assets.df = pd.concat(dfs, ignore_index=True, sort=True)
 
     def calc_all(self):
         """

--- a/ccc/calculator.py
+++ b/ccc/calculator.py
@@ -156,7 +156,7 @@ class Calculator:
                     self.__p.profit_rate,
                     self.__p.u[t],
                 )
-        df = pd.concat(dfs, ignore_index=True, copy=True)
+        df = pd.concat(dfs, ignore_index=True)
 
         return df
 
@@ -217,7 +217,7 @@ class Calculator:
                         )
                     )
         self.__assets.df = pd.concat(
-            dfs, ignore_index=True, copy=True, sort=True
+            dfs, ignore_index=True, sort=True
         )
 
     def calc_all(self):
@@ -292,7 +292,6 @@ class Calculator:
         df = pd.concat(
             [asset_df, minor_asset_df, major_asset_df, overall_df],
             ignore_index=True,
-            copy=True,
             sort=True,
         ).reset_index()
         # Drop duplicate rows in case, e.g., only one asset in major
@@ -354,7 +353,6 @@ class Calculator:
         df = pd.concat(
             [ind_df, major_ind_df, overall_df],
             ignore_index=True,
-            copy=True,
             sort=True,
         ).reset_index()
         # Drop duplicate rows in case, e.g., only one industry in major
@@ -434,7 +432,7 @@ class Calculator:
             # Put df's together
             dfs_out.append(
                 pd.concat(
-                    [treat_df, all_df], ignore_index=True, copy=True, sort=True
+                    [treat_df, all_df], ignore_index=True, sort=True
                 ).reset_index()
             )
         base_tab = dfs_out[0]
@@ -687,7 +685,6 @@ class Calculator:
                 pd.concat(
                     [major_asset_df, treat_df, all_df],
                     ignore_index=True,
-                    copy=True,
                     sort=True,
                 ).reset_index()
             )
@@ -890,7 +887,6 @@ class Calculator:
                 pd.concat(
                     [major_ind_df, treat_df, all_df],
                     ignore_index=True,
-                    copy=True,
                     sort=True,
                 ).reset_index()
             )

--- a/ccc/default_parameters.json
+++ b/ccc/default_parameters.json
@@ -6,7 +6,7 @@
                 "validators": {
                     "range": {
                         "min": 2013,
-                        "max": 2035
+                        "max": 2036
                     }
                 }
             },

--- a/ccc/default_parameters.json
+++ b/ccc/default_parameters.json
@@ -6,7 +6,7 @@
                 "validators": {
                     "range": {
                         "min": 2013,
-                        "max": 2036
+                        "max": 2035
                     }
                 }
             },

--- a/ccc/get_taxcalc_rates.py
+++ b/ccc/get_taxcalc_rates.py
@@ -51,10 +51,12 @@ def get_calculator(
     elif data is None or "puf" in str(data):  # pragma: no cover
         print("Using PUF")
         gf_base = GrowFactors()
+        data = "puf.csv" if data is None else data
+        weights = "puf_weights.csv.gz" if weights is None else weights
         records1 = Records.puf_constructor(
-            data="puf.csv",
+            data=data,
             gfactors=gf_base,
-            weights="puf_weights.csv.gz",
+            weights=weights,
         )
     elif data is not None and "tmd" in str(data):  # pragma: no cover
         print("Using TMD")

--- a/ccc/get_taxcalc_rates.py
+++ b/ccc/get_taxcalc_rates.py
@@ -50,7 +50,12 @@ def get_calculator(
         records1.e01100 = np.zeros(records1.e01100.shape[0])
     elif data is None or "puf" in str(data):  # pragma: no cover
         print("Using PUF")
-        records1 = Records()
+        gf_base = GrowFactors()
+        records1 = Records.puf_constructor(
+            data="puf.csv",
+            gfactors=gf_base,
+            weights="puf_weights.csv.gz",
+        )
     elif data is not None and "tmd" in str(data):  # pragma: no cover
         print("Using TMD")
         records1 = Records.tmd_constructor(data, weights, gfactors)

--- a/ccc/tax_depreciation_rules.json
+++ b/ccc/tax_depreciation_rules.json
@@ -3,7 +3,7 @@
         "labels": {
             "year": {
                 "type": "int",
-                "validators": {"range": {"min": 2013, "max": 2035}}
+                "validators": {"range": {"min": 2013, "max": 2036}}
             },
             "system": {
                 "type": "str",

--- a/ccc/tests/test_calcfunctions.py
+++ b/ccc/tests/test_calcfunctions.py
@@ -257,6 +257,9 @@ def test_update_depr_methods(monkeypatch):
     test_df = cf.update_depr_methods(asset_df, p, dp)
     print("Test df =", test_df)
 
+    print("DP = ")
+    print(dp.to_df())
+
     assert_frame_equal(test_df, expected_df, check_like=True)
 
 

--- a/ccc/tests/test_calcfunctions.py
+++ b/ccc/tests/test_calcfunctions.py
@@ -253,12 +253,7 @@ def test_update_depr_methods(monkeypatch):
     expected_df["Y"] = pd.Series(
         [10, 10, 3, 15, 27.5, 27.5, 10, 3, 15, 7], index=expected_df.index
     )
-    print("Expected df =", expected_df)
     test_df = cf.update_depr_methods(asset_df, p, dp)
-    print("Test df =", test_df)
-
-    print("DP = ")
-    print(dp.to_df())
 
     assert_frame_equal(test_df, expected_df, check_like=True)
 

--- a/ccc/tests/test_get_taxcalc_rates.py
+++ b/ccc/tests/test_get_taxcalc_rates.py
@@ -6,7 +6,6 @@ from ccc import get_taxcalc_rates as tc
 from ccc.parameters import Specification
 from ccc.utils import TC_LAST_YEAR
 
-
 CUR_DIR = os.path.abspath(os.path.dirname(__file__))
 
 

--- a/ccc/tests/test_get_taxcalc_rates.py
+++ b/ccc/tests/test_get_taxcalc_rates.py
@@ -73,7 +73,7 @@ def test_get_calculator_tmd(data, weights, growfactors):
         weights=weights,
         gfactors=growfactors,
     )
-    assert calc1.current_year == 2021
+    assert calc1.current_year == 2022
 
 
 def test_get_calculator_exception():

--- a/ccc/tests/test_parameters.py
+++ b/ccc/tests/test_parameters.py
@@ -3,7 +3,6 @@ import os
 from ccc.parameters import Specification, revision_warnings_errors
 from ccc.parameters import DepreciationParams
 
-
 CUR_DIR = os.path.abspath(os.path.dirname(__file__))
 test_data = [(27.5, "27_5"), (30, "30")]
 

--- a/ccc/tests/test_run_ccc.py
+++ b/ccc/tests/test_run_ccc.py
@@ -9,7 +9,6 @@ from ccc.parameters import Specification, DepreciationParams
 from ccc.calculator import Calculator
 from ccc.data import Assets
 
-
 TDIR = os.path.abspath(os.path.dirname(__file__))
 
 

--- a/ccc/utils.py
+++ b/ccc/utils.py
@@ -2,7 +2,6 @@ import importlib.resources as pkg_resources
 from collections import OrderedDict
 import warnings
 import numbers
-import os
 import json
 import pandas as pd
 
@@ -19,7 +18,7 @@ ASSET_DATA_CSV_YEAR = 2013
 RECORDS_START_YEAR = 2011
 
 # Latest year TaxData extrapolates to
-TC_LAST_YEAR = 2035
+TC_LAST_YEAR = 2036
 
 
 def to_str(x):

--- a/cs-config/cs_config/functions.py
+++ b/cs-config/cs_config/functions.py
@@ -14,6 +14,9 @@ import cs2tc
 
 AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID")
 AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY")
+PUF_WEIGHTS_S3_FILE_LOCATION = os.environ.get(
+    "PUF_WEIGHTS_S3_LOCATION", "s3://ospc-data-files/puf_weights.20210720.csv.gz"  ## This needs to be updated
+)
 PUF_S3_FILE_LOCATION = os.environ.get(
     "PUF_S3_LOCATION", "s3://ospc-data-files/puf.20210720.csv.gz"
 )
@@ -184,7 +187,9 @@ def run_model(meta_param_dict, adjustment):
         data = retrieve_puf(
             PUF_S3_FILE_LOCATION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
         )
-        weights = Records.PUF_WEIGHTS_FILENAME
+        weights = retrieve_puf(
+            PUF_WEIGHTS_S3_FILE_LOCATION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+        )
         records_start_year = Records.PUFCSV_YEAR
         if data is not None:
             if not isinstance(data, pd.DataFrame):
@@ -208,7 +213,7 @@ def run_model(meta_param_dict, adjustment):
             meta_params.adjust({"data_source": "CPS"})
     elif meta_params.data_source == "CPS":
         data = "cps"
-        weights = Records.PUF_WEIGHTS_FILENAME
+        weights = os.path.join(Records.CODE_PATH, 'cps_weights.csv.gz')
         records_start_year = Records.CPSCSV_YEAR
     else:
         raise ValueError(

--- a/cs-config/cs_config/functions.py
+++ b/cs-config/cs_config/functions.py
@@ -16,7 +16,7 @@ AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID")
 AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY")
 PUF_WEIGHTS_S3_FILE_LOCATION = os.environ.get(
     "PUF_WEIGHTS_S3_LOCATION",
-    "s3://ospc-data-files/puf_weights.20210720.csv.gz",  ## This needs to be updated
+    "s3://ospc-data-files/puf_weights.20210720.csv.gz",  # TODO: This needs to be updated
 )
 PUF_S3_FILE_LOCATION = os.environ.get(
     "PUF_S3_LOCATION", "s3://ospc-data-files/puf.20210720.csv.gz"
@@ -197,6 +197,8 @@ def run_model(meta_param_dict, adjustment):
         if data is not None:
             if not isinstance(data, pd.DataFrame):
                 raise TypeError("'data' must be a Pandas DataFrame.")
+        if weights is None:
+            raise ValueError("Weights data could not be retrieved.")
         else:
             # Access keys are not available. Default to the CPS.
             print("Defaulting to the CPS")

--- a/cs-config/cs_config/functions.py
+++ b/cs-config/cs_config/functions.py
@@ -15,7 +15,8 @@ import cs2tc
 AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID")
 AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY")
 PUF_WEIGHTS_S3_FILE_LOCATION = os.environ.get(
-    "PUF_WEIGHTS_S3_LOCATION", "s3://ospc-data-files/puf_weights.20210720.csv.gz"  ## This needs to be updated
+    "PUF_WEIGHTS_S3_LOCATION",
+    "s3://ospc-data-files/puf_weights.20210720.csv.gz",  ## This needs to be updated
 )
 PUF_S3_FILE_LOCATION = os.environ.get(
     "PUF_S3_LOCATION", "s3://ospc-data-files/puf.20210720.csv.gz"
@@ -188,7 +189,9 @@ def run_model(meta_param_dict, adjustment):
             PUF_S3_FILE_LOCATION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
         )
         weights = retrieve_puf(
-            PUF_WEIGHTS_S3_FILE_LOCATION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+            PUF_WEIGHTS_S3_FILE_LOCATION,
+            AWS_ACCESS_KEY_ID,
+            AWS_SECRET_ACCESS_KEY,
         )
         records_start_year = Records.PUFCSV_YEAR
         if data is not None:
@@ -213,7 +216,7 @@ def run_model(meta_param_dict, adjustment):
             meta_params.adjust({"data_source": "CPS"})
     elif meta_params.data_source == "CPS":
         data = "cps"
-        weights = os.path.join(Records.CODE_PATH, 'cps_weights.csv.gz')
+        weights = os.path.join(Records.CODE_PATH, "cps_weights.csv.gz")
         records_start_year = Records.CPSCSV_YEAR
     else:
         raise ValueError(

--- a/docs/book/_config.yml
+++ b/docs/book/_config.yml
@@ -2,7 +2,7 @@
 # Book settings
 title                    : Cost-of-Capital-Calculator
 author                   : Jason DeBacker
-copyright                : '2025'
+copyright                : '2026'
 logo                     : '../ccc.png'
 
 ####################################################

--- a/docs/book/content/intro.md
+++ b/docs/book/content/intro.md
@@ -14,12 +14,12 @@ or with PyPI via:
 
 
 ## Web Application
-You can also use Cost-of-Capital-Calculator through a web
-application, hosted on [Compute Studio](https://compute.studio/PSLmodels/Cost-of-Capital-Calculator/). The web application is limited in that you cannot consider policy reforms to the individual income tax code, but it is an easy to use alternative to the Python API.
+Previously, you could also use Cost-of-Capital-Calculator through a web
+application, hosted on [Compute Studio](https://compute.studio/PSLmodels/Cost-of-Capital-Calculator/). The web application is limited in that you cannot consider policy reforms to the individual income tax code, but it is an easy to use alternative to the Python API.  Please reach out if you have funding to help support the hosting of the web application, which is currently not being maintained.
 
 ## Disclaimer
 Results will change as the underlying models improve. A fundamental reason for adopting open source methods in this project is so that people from all backgrounds can contribute to the models that our society uses to assess economic policy; when community-contributed improvements are incorporated, the model will produce different results.
 
 
 ## Citing the Cost-of-Capital-Calculator Model
-Cost-of-Capital-Calculator (Version 2.1.0)[Source code], https://github.com/PSLmodels/Cost-of-Capital-Calculator
+Cost-of-Capital-Calculator (Version 2.1.1)[Source code], https://github.com/PSLmodels/Cost-of-Capital-Calculator

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
 - coverage
 - black
 - pip:
-  - taxcalc>=5.2.0
-  - jupyter-book
+  - taxcalc>=6.0.0
+  - "jupyter-book<2.0.0"
   - "cs-kit>=1.16.8"
   - cs2tc

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     download_url="https://github.com/PSLmodels/Cost-of-Capital-Calculator",
     long_description_content_type="text/markdown",
     long_description=longdesc,
-    version="2.1.0",
+    version="2.1.1",
     license="CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     packages=["ccc"],
     include_package_data=True,


### PR DESCRIPTION
This PR modernizes CCC to work with the latests versions of Tax-Calculator. It also fixes errors due to deprecations in package dependencies.